### PR TITLE
[FEAT] BE Dev 환경 CI/CD 스크립트 작성

### DIFF
--- a/backend/.github/workflows/be-cd-dev.yml
+++ b/backend/.github/workflows/be-cd-dev.yml
@@ -1,4 +1,4 @@
-name: BE CI for Dev
+name: BE CD for Dev
 
 on:
   pull_request:
@@ -10,34 +10,9 @@ permissions:
   contents: read
 
 jobs:
-#  # docker 이동 시, 사용
-#  build:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: checkout
-#        uses: actions/checkout@v4
-#
-#      - name: Set up JDK 17
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: '17'
-#          distribution: 'temurin'
-#
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#
-#      - name: Build with Gradle
-#        run: ./gradlew clean bootJar
-
   deploy:
-#    needs: build
-    runs-on: [self-hosted, linux, ARM64]
+    runs-on: [self-hosted, linux, ARM64] # Self hosted runner 사용
 
-      # EC2에 배포
-      # EC2 SSH 키를 private_key.pem 파일로 저장 ( 위치는 GitHub 서버 )
-      # SSH를 사용하여 EC2 서버에 연결하고 현재 실행 중인 Java 프로세스를 종료한 다음 새로운 Java 프로세스 생성 및 실행!!
-    ## NLP 적용하면 IP -> 도메인으로 수정 + EC2 늘리면 run 추가
     steps:
       - name: Deploy to EC2
         run: |

--- a/backend/.github/workflows/be-cd-dev.yml
+++ b/backend/.github/workflows/be-cd-dev.yml
@@ -1,0 +1,47 @@
+name: BE CI for Dev
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+    paths:
+      - backend/**
+
+permissions:
+  contents: read
+
+jobs:
+#  # docker 이동 시, 사용
+#  build:
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: checkout
+#        uses: actions/checkout@v4
+#
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#
+#      - name: Grant execute permission for gradlew
+#        run: chmod +x gradlew
+#
+#      - name: Build with Gradle
+#        run: ./gradlew clean bootJar
+
+  deploy:
+#    needs: build
+    runs-on: [self-hosted, linux, ARM64]
+
+      # EC2에 배포
+      # EC2 SSH 키를 private_key.pem 파일로 저장 ( 위치는 GitHub 서버 )
+      # SSH를 사용하여 EC2 서버에 연결하고 현재 실행 중인 Java 프로세스를 종료한 다음 새로운 Java 프로세스 생성 및 실행!!
+    ## NLP 적용하면 IP -> 도메인으로 수정 + EC2 늘리면 run 추가
+    steps:
+      - name: Deploy to EC2
+        run: |
+          echo "${{ secrets.EC2_DEV_SSH_KEY }}" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem ${{ secrets.EC2_DEV_USERNAME }}@${{ secrets.EC2_DEV_IP }} | sh deploy-script-dev.sh
+          rm -f private_key.pem

--- a/backend/.github/workflows/be-ci-dev.yml
+++ b/backend/.github/workflows/be-ci-dev.yml
@@ -1,0 +1,30 @@
+name: BE CI for Dev
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+    paths:
+      - backend/**
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,6 +14,10 @@ java {
     }
 }
 
+jar {
+    enabled = false
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor


### PR DESCRIPTION
## Issue Number
#18 

## As-Is
<!-- 문제 상황 정의 -->
- AWS ssh 포트, IAM 사용 권한이 제한된 상황에서 가능한 CI/CD 스크립트를 작성하여
자동 배포를 수행하도록 만든다.

## To-Be
<!-- 변경 사항 -->
- BE Dev 환경 CI 세팅
- BE Dev 환경 CD 세팅
- BE Dev 운영환경(EC2)에 Github self hosted Runner 세팅
  - 22번 포트가 우테코 LAN 에서만 사용할 수 있기 때문에 self hosted runner로 EC2 내부에서 CD 스크립트를 동작하도록 한다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
