### PR TITLE
[FIX] cd 스크립트 동작 시점 PR -> Push 시점으로 변경

### DIFF
--- a/backend/.github/workflows/be-cd-dev.yml
+++ b/backend/.github/workflows/be-cd-dev.yml
@@ -1,7 +1,7 @@
 name: BE CD for Dev
 
 on:
-  pull_request:
+  push:
     branches: [ "develop" ]
     paths:
       - backend/**


### PR DESCRIPTION
## Issue Number
#22 

## As-Is
<!-- 문제 상황 정의 -->
cd 스크립트 동작 시점이 `Develop 브랜치에 PR이 생성되었을 때` 로 설정되어 있었다.

## To-Be
<!-- 변경 사항 -->
cd 스크립트 동작 시점을 `Develop 브랜치에 Push가 발생했을 때` 로 변경하였다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
