### PR TITLE
[FEAT] 주제, 선택지 조회 디능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/ddangkong/controller/exception/BusinessLogicException.java
+++ b/backend/src/main/java/ddangkong/controller/exception/BusinessLogicException.java
@@ -1,0 +1,8 @@
+package ddangkong.controller.exception;
+
+public class BusinessLogicException extends RuntimeException {
+
+    public BusinessLogicException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class GlobalExceptionHandler {
 
+    private static final String SERVER_ERROR_MESSAGE = "서버 오류가 발생했습니다. 관리자에게 문의하세요.";
+
     @ExceptionHandler
     public ErrorResponse handleBindingException(BindException e) {
         log.warn(e.getMessage());
@@ -27,10 +29,26 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleBusinessLogicException(BusinessLogicException e) {
+        log.warn(e.getMessage());
+
+        return new ErrorResponse(e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleViolateDataException(ViolateDataException e) {
+        log.warn(e.getMessage());
+
+        return new ErrorResponse(SERVER_ERROR_MESSAGE);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleException(Exception e) {
         log.error(e.getMessage());
 
-        return new ErrorResponse("서버 오류가 발생했습니다. 관리자에게 문의하세요.");
+        return new ErrorResponse(SERVER_ERROR_MESSAGE);
     }
 }

--- a/backend/src/main/java/ddangkong/controller/exception/ViolateDataException.java
+++ b/backend/src/main/java/ddangkong/controller/exception/ViolateDataException.java
@@ -1,0 +1,8 @@
+package ddangkong.controller.exception;
+
+public class ViolateDataException extends RuntimeException {
+
+    public ViolateDataException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/option/dto/BalanceOptionResponse.java
+++ b/backend/src/main/java/ddangkong/controller/option/dto/BalanceOptionResponse.java
@@ -1,0 +1,12 @@
+package ddangkong.controller.option.dto;
+
+import ddangkong.domain.option.BalanceOption;
+
+public record BalanceOptionResponse(
+        Long optionId,
+        String content
+) {
+    public static BalanceOptionResponse from(BalanceOption balanceOption) {
+        return new BalanceOptionResponse(balanceOption.getId(), balanceOption.getContent());
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/question/BalanceQuestionController.java
+++ b/backend/src/main/java/ddangkong/controller/question/BalanceQuestionController.java
@@ -1,0 +1,22 @@
+package ddangkong.controller.question;
+
+import ddangkong.controller.question.dto.BalanceQuestionResponse;
+import ddangkong.service.question.BalanceQuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class BalanceQuestionController {
+
+    private final BalanceQuestionService balanceQuestionService;
+
+    @GetMapping("/balances/rooms/{roomId}/question")
+    public BalanceQuestionResponse getBalanceQuestion(@PathVariable Long roomId) {
+        return balanceQuestionService.findRecentBalanceQuestion(roomId);
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/question/dto/BalanceQuestionResponse.java
+++ b/backend/src/main/java/ddangkong/controller/question/dto/BalanceQuestionResponse.java
@@ -1,0 +1,24 @@
+package ddangkong.controller.question.dto;
+
+import ddangkong.controller.option.dto.BalanceOptionResponse;
+import ddangkong.domain.option.BalanceOption;
+import ddangkong.domain.question.BalanceQuestion;
+import ddangkong.domain.question.Category;
+import lombok.Builder;
+
+public record BalanceQuestionResponse(
+        Long questionId,
+        Category category,
+        String title,
+        BalanceOptionResponse firstOption,
+        BalanceOptionResponse secondOption
+) {
+    @Builder
+    private BalanceQuestionResponse(BalanceQuestion question, BalanceOption firstOption, BalanceOption secondOption) {
+        this(question.getId(),
+                question.getCategory(),
+                question.getContent(),
+                BalanceOptionResponse.from(firstOption),
+                BalanceOptionResponse.from(secondOption));
+    }
+}

--- a/backend/src/main/java/ddangkong/domain/AuditingEntity.java
+++ b/backend/src/main/java/ddangkong/domain/AuditingEntity.java
@@ -1,0 +1,19 @@
+package ddangkong.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class AuditingEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/ddangkong/domain/room/RoomQuestion.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomQuestion.java
@@ -1,5 +1,6 @@
 package ddangkong.domain.room;
 
+import ddangkong.domain.AuditingEntity;
 import ddangkong.domain.question.BalanceQuestion;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,7 +20,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class RoomQuestion {
+public class RoomQuestion extends AuditingEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/ddangkong/repository/option/BalanceOptionRepository.java
+++ b/backend/src/main/java/ddangkong/repository/option/BalanceOptionRepository.java
@@ -1,0 +1,13 @@
+package ddangkong.repository.option;
+
+import ddangkong.domain.option.BalanceOption;
+import ddangkong.domain.question.BalanceQuestion;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BalanceOptionRepository extends JpaRepository<BalanceOption, Long> {
+
+    List<BalanceOption> findByBalanceQuestion(BalanceQuestion balanceQuestion);
+}

--- a/backend/src/main/java/ddangkong/repository/room/RoomQuestionRepository.java
+++ b/backend/src/main/java/ddangkong/repository/room/RoomQuestionRepository.java
@@ -1,0 +1,12 @@
+package ddangkong.repository.room;
+
+import ddangkong.domain.room.RoomQuestion;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomQuestionRepository extends JpaRepository<RoomQuestion, Long> {
+
+    Optional<RoomQuestion> findTopByRoomIdOrderByCreatedAtDesc(Long roomId);
+}

--- a/backend/src/main/java/ddangkong/service/question/BalanceQuestionService.java
+++ b/backend/src/main/java/ddangkong/service/question/BalanceQuestionService.java
@@ -1,0 +1,54 @@
+package ddangkong.service.question;
+
+import ddangkong.controller.exception.BusinessLogicException;
+import ddangkong.controller.exception.ViolateDataException;
+import ddangkong.controller.question.dto.BalanceQuestionResponse;
+import ddangkong.domain.option.BalanceOption;
+import ddangkong.domain.question.BalanceQuestion;
+import ddangkong.repository.option.BalanceOptionRepository;
+import ddangkong.repository.room.RoomQuestionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BalanceQuestionService {
+
+    private static final int BALANCE_OPTION_SIZE = 2;
+
+    private final RoomQuestionRepository roomQuestionRepository;
+
+    private final BalanceOptionRepository balanceOptionRepository;
+
+    @Transactional(readOnly = true)
+    public BalanceQuestionResponse findRecentBalanceQuestion(Long roomId) {
+        BalanceQuestion balanceQuestion = findRecentQuestion(roomId);
+        List<BalanceOption> balanceOptions = findBalanceOptions(balanceQuestion);
+
+        return BalanceQuestionResponse.builder()
+                .question(balanceQuestion)
+                .firstOption(balanceOptions.get(0))
+                .secondOption(balanceOptions.get(1))
+                .build();
+    }
+
+    private BalanceQuestion findRecentQuestion(Long roomId) {
+        return roomQuestionRepository.findTopByRoomIdOrderByCreatedAtDesc(roomId)
+                .orElseThrow(() -> new BusinessLogicException("해당 방의 질문이 존재하지 않습니다."))
+                .getBalanceQuestion();
+    }
+
+    private List<BalanceOption> findBalanceOptions(BalanceQuestion balanceQuestion) {
+        List<BalanceOption> balanceOptions = balanceOptionRepository.findByBalanceQuestion(balanceQuestion);
+        validateBalanceOptions(balanceOptions);
+        return balanceOptions;
+    }
+
+    private void validateBalanceOptions(List<BalanceOption> balanceOptions) {
+        if (balanceOptions.size() != BALANCE_OPTION_SIZE) {
+            throw new ViolateDataException("밸런스 게임의 선택지가 %d개입니다".formatted(balanceOptions.size()));
+        }
+    }
+}

--- a/backend/src/test/java/ddangkong/controller/BaseControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/BaseControllerTest.java
@@ -1,0 +1,21 @@
+package ddangkong.controller;
+
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "/init-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public abstract class BaseControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}

--- a/backend/src/test/java/ddangkong/controller/question/BalanceQuestionControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/question/BalanceQuestionControllerTest.java
@@ -1,0 +1,34 @@
+package ddangkong.controller.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ddangkong.controller.BaseControllerTest;
+import ddangkong.controller.option.dto.BalanceOptionResponse;
+import ddangkong.controller.question.dto.BalanceQuestionResponse;
+import ddangkong.domain.question.Category;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BalanceQuestionControllerTest extends BaseControllerTest {
+
+    private static final BalanceQuestionResponse EXPECTED_RESPONSE = new BalanceQuestionResponse(
+            1L, Category.EXAMPLE, "똥 맛 카레 vs 카레 맛 똥",
+            new BalanceOptionResponse(1L, "똥 맛 카레"),
+            new BalanceOptionResponse(2L, "카레 맛 똥"));
+
+    @Nested
+    class 방의_질문_조회 {
+
+        @Test
+        void 현재_방의_질문을_조회할_수_있다() {
+            BalanceQuestionResponse actual = RestAssured.given().log().all()
+                    .when().get("/api/balances/rooms/1/question")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract().as(BalanceQuestionResponse.class);
+
+            assertThat(actual).isEqualTo(EXPECTED_RESPONSE);
+        }
+    }
+}

--- a/backend/src/test/java/ddangkong/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/repository/BaseRepositoryTest.java
@@ -1,0 +1,9 @@
+package ddangkong.repository;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@DataJpaTest
+@Sql(scripts = "/init-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public abstract class BaseRepositoryTest {
+}

--- a/backend/src/test/java/ddangkong/repository/room/RoomQuestionRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/repository/room/RoomQuestionRepositoryTest.java
@@ -1,0 +1,26 @@
+package ddangkong.repository.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ddangkong.domain.room.RoomQuestion;
+import ddangkong.repository.BaseRepositoryTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RoomQuestionRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    private RoomQuestionRepository roomQuestionRepository;
+
+    @Nested
+    class 방의_최신_질문_조회 {
+
+        @Test
+        void 방의_가장_최신의_질문을_조회할_수_있다() {
+            RoomQuestion actual = roomQuestionRepository.findTopByRoomIdOrderByCreatedAtDesc(1L).get();
+
+            assertThat(actual.getId()).isEqualTo(1L);
+        }
+    }
+}

--- a/backend/src/test/java/ddangkong/service/BaseServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/BaseServiceTest.java
@@ -1,0 +1,11 @@
+package ddangkong.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "/init-test.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public abstract class BaseServiceTest {
+}

--- a/backend/src/test/java/ddangkong/service/question/BalanceQuestionServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/question/BalanceQuestionServiceTest.java
@@ -1,0 +1,44 @@
+package ddangkong.service.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ddangkong.controller.exception.BusinessLogicException;
+import ddangkong.controller.option.dto.BalanceOptionResponse;
+import ddangkong.controller.question.dto.BalanceQuestionResponse;
+import ddangkong.domain.question.Category;
+import ddangkong.service.BaseServiceTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class BalanceQuestionServiceTest extends BaseServiceTest {
+
+    private static final Long PROGRESS_ROOM_ID = 1L;
+    private static final Long NOT_EXIST_ROOM_ID = 2L;
+    private static final BalanceQuestionResponse BALANCE_QUESTION_RESPONSE = new BalanceQuestionResponse(
+        1L, Category.EXAMPLE, "똥 맛 카레 vs 카레 맛 똥",
+            new BalanceOptionResponse(1L, "똥 맛 카레"),
+            new BalanceOptionResponse(2L, "카레 맛 똥"));
+
+    @Autowired
+    private BalanceQuestionService balanceQuestionService;
+
+    @Nested
+    class 방의_최신_질문_조회 {
+
+        @Test
+        void 방의_최신_질문을_조회할_수_있다() {
+            BalanceQuestionResponse actual = balanceQuestionService.findRecentBalanceQuestion(PROGRESS_ROOM_ID);
+
+            assertThat(actual).isEqualTo(BALANCE_QUESTION_RESPONSE);
+        }
+
+        @Test
+        void 방이_없을_경우_예외를_던진다() {
+            assertThatThrownBy(() -> balanceQuestionService.findRecentBalanceQuestion(NOT_EXIST_ROOM_ID))
+                    .isInstanceOf(BusinessLogicException.class)
+                    .hasMessage("해당 방의 질문이 존재하지 않습니다.");
+        }
+    }
+}

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -1,0 +1,36 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+
+TRUNCATE TABLE member;
+TRUNCATE TABLE balance_option;
+TRUNCATE TABLE balance_question;
+TRUNCATE TABLE balance_vote;
+TRUNCATE TABLE room;
+TRUNCATE TABLE room_question;
+
+ALTER TABLE member ALTER COLUMN ID RESTART WITH 1;
+ALTER TABLE balance_option ALTER COLUMN ID RESTART WITH 1;
+ALTER TABLE balance_question ALTER COLUMN ID RESTART WITH 1;
+ALTER TABLE balance_vote ALTER COLUMN ID RESTART WITH 1;
+ALTER TABLE room ALTER COLUMN ID RESTART WITH 1;
+ALTER TABLE room_question ALTER COLUMN ID RESTART WITH 1;
+
+INSERT INTO room() VALUES ();
+
+INSERT INTO member(nickname, room_id) VALUES ('mohamedeu al katan', 1);
+INSERT INTO member(nickname, room_id) VALUES ('deundeun ', 1);
+INSERT INTO member(nickname, room_id) VALUES ('rupi', 1);
+INSERT INTO member(nickname, room_id) VALUES ('rapper lee', 1);
+
+INSERT INTO room_question(room_id, balance_question_id, created_at) VALUES (1, 1, '2024-07-18 20:00:00.000');
+
+INSERT INTO balance_question(category, content) VALUES ('EXAMPLE', '똥 맛 카레 vs 카레 맛 똥');
+
+INSERT INTO balance_option(content, balance_question_id) VALUES ('똥 맛 카레', 1);
+INSERT INTO balance_option(content, balance_question_id) VALUES ('카레 맛 똥', 1);
+
+INSERT INTO balance_vote(balance_option_id, member_id) VALUES (1, 1);
+INSERT INTO balance_vote(balance_option_id, member_id) VALUES (1, 2);
+INSERT INTO balance_vote(balance_option_id, member_id) VALUES (1, 3);
+INSERT INTO balance_vote(balance_option_id, member_id) VALUES (2, 4);
+
+SET REFERENTIAL_INTEGRITY TRUE;


### PR DESCRIPTION
## Issue Number
#28

## As-Is
<!-- 문제 상황 정의 -->
방에 진행 중인(가장 최신의) 주제, 선택지 조회 기능 필요

## To-Be
<!-- 변경 사항 -->
방에 진행 중인(가장 최신의) 주제, 선택지 조회 기능 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/c72bf44c-248e-4ae4-a454-ce0d54005b89)

## (Optional) Additional Description
- [백엔드 논의 짬통](https://www.notion.so/ghenmaru/78ef6307b95a4f4e85352973eae97880) 확인 부탁해요~