### PR TITLE
[FEAT] truncate extension

### DIFF
--- a/backend/src/test/java/ddangkong/controller/BaseControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/BaseControllerTest.java
@@ -1,13 +1,18 @@
 package ddangkong.controller;
 
 
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import ddangkong.support.extension.DatabaseCleanerExtension;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "/init-test.sql")
 public abstract class BaseControllerTest {
 

--- a/backend/src/test/java/ddangkong/domain/BaseRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/domain/BaseRepositoryTest.java
@@ -4,7 +4,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
-@Sql(scripts = "/init-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/init-test.sql")
 public abstract class BaseRepositoryTest {
-
 }

--- a/backend/src/test/java/ddangkong/domain/balance/content/RoomContentRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/domain/balance/content/RoomContentRepositoryTest.java
@@ -18,10 +18,10 @@ class RoomContentRepositoryTest extends BaseRepositoryTest {
         @Test
         void 방의_가장_최신의_질문을_조회할_수_있다() {
             // given
-            Long recentContentId = 1L;
+            Long roomId = 1L;
 
             // when
-            RoomContent actual = roomContentRepository.findTopByRoomIdOrderByCreatedAtDesc(recentContentId).get();
+            RoomContent actual = roomContentRepository.findTopByRoomIdOrderByCreatedAtDesc(roomId).get();
 
             // then
             assertThat(actual.getId()).isEqualTo(2L);

--- a/backend/src/test/java/ddangkong/service/BaseServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/BaseServiceTest.java
@@ -1,9 +1,14 @@
 package ddangkong.service;
 
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import ddangkong.support.extension.DatabaseCleanerExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
-@SpringBootTest
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @Sql(scripts = "/init-test.sql")
 public abstract class BaseServiceTest {
 }

--- a/backend/src/test/java/ddangkong/support/extension/DatabaseCleanerExtension.java
+++ b/backend/src/test/java/ddangkong/support/extension/DatabaseCleanerExtension.java
@@ -1,0 +1,47 @@
+package ddangkong.support.extension;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        ApplicationContext context = SpringExtension.getApplicationContext(extensionContext);
+        cleanup(context);
+    }
+
+    private void cleanup(ApplicationContext context) {
+        EntityManager em = context.getBean(EntityManager.class);
+        TransactionTemplate transactionTemplate = context.getBean(TransactionTemplate.class);
+
+        transactionTemplate.execute(action -> {
+            em.clear();
+            truncateTables(em);
+            return null;
+        });
+    }
+
+    private void truncateTables(EntityManager em) {
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : findTableNames(em)) {
+            em.createNativeQuery("TRUNCATE TABLE %s RESTART IDENTITY".formatted(tableName)).executeUpdate();
+        }
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> findTableNames(EntityManager em) {
+        String tableSelectQuery = """
+                SELECT TABLE_NAME
+                FROM INFORMATION_SCHEMA.TABLES
+                WHERE TABLE_SCHEMA = 'PUBLIC'
+                """;
+        return em.createNativeQuery(tableSelectQuery).getResultList();
+    }
+}

--- a/backend/src/test/java/ddangkong/support/extension/DatabaseCleanerExtension.java
+++ b/backend/src/test/java/ddangkong/support/extension/DatabaseCleanerExtension.java
@@ -37,11 +37,11 @@ public class DatabaseCleanerExtension implements BeforeEachCallback {
 
     @SuppressWarnings("unchecked")
     private List<String> findTableNames(EntityManager em) {
-        String tableSelectQuery = """
+        String tableNameSelectQuery = """
                 SELECT TABLE_NAME
                 FROM INFORMATION_SCHEMA.TABLES
                 WHERE TABLE_SCHEMA = 'PUBLIC'
                 """;
-        return em.createNativeQuery(tableSelectQuery).getResultList();
+        return em.createNativeQuery(tableNameSelectQuery).getResultList();
     }
 }

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -1,34 +1,32 @@
-SET REFERENTIAL_INTEGRITY FALSE;
+INSERT INTO room ()
+VALUES ();
 
-TRUNCATE TABLE member;
-TRUNCATE TABLE balance_option;
-TRUNCATE TABLE balance_content;
-TRUNCATE TABLE balance_vote;
-TRUNCATE TABLE room;
-TRUNCATE TABLE room_content;
+INSERT INTO member (nickname, room_id)
+VALUES ('mohamedeu al katan', 1),
+       ('deundeun', 1),
+       ('rupi', 1),
+       ('rapper lee', 1);
 
-ALTER TABLE member ALTER COLUMN ID RESTART WITH 1;
-ALTER TABLE balance_option ALTER COLUMN ID RESTART WITH 1;
-ALTER TABLE balance_content ALTER COLUMN ID RESTART WITH 1;
-ALTER TABLE balance_vote ALTER COLUMN ID RESTART WITH 1;
-ALTER TABLE room ALTER COLUMN ID RESTART WITH 1;
-ALTER TABLE room_content ALTER COLUMN ID RESTART WITH 1;
+INSERT INTO balance_content (category, name)
+VALUES ('EXAMPLE', '민초 vs 반민초'),
+       ('EXAMPLE', '월 200 백수 vs 월 500 직장인');
 
-INSERT INTO room() VALUES ();
+INSERT INTO room_content (room_id, balance_content_id, created_at)
+VALUES (1, 2, '2024-07-18 19:50:00.000'),
+       (1, 1, '2024-07-18 20:00:00.000');
 
-INSERT INTO member(nickname, room_id)
-VALUES ('mohamedeu al katan', 1), ('deundeun', 1), ('rupi', 1), ('rapper lee', 1);
+INSERT INTO balance_option (name, balance_content_id)
+VALUES ('민초', 1),
+       ('반민초', 1),
+       ('월 200 백수', 2),
+       ('월 200 직장인', 2);
 
-INSERT INTO room_content(room_id, balance_content_id, created_at)
-VALUES (1, 2, '2024-07-18 19:50:00.000'), (1, 1, '2024-07-18 20:00:00.000');
-
-INSERT INTO balance_content(category, name)
-VALUES ('EXAMPLE', '민초 vs 반민초'), ('EXAMPLE', '월 200 백수 vs 월 500 직장인');
-
-INSERT INTO balance_option(name, balance_content_id)
-VALUES ('민초', 1), ('반민초', 1), ('월 200 백수', 2), ('월 200 직장인', 2);
-
-INSERT INTO balance_vote(balance_option_id, member_id)
-VALUES (4, 1), (4, 2), (4, 3), (4, 4), (1, 1), (1, 2), (1, 3), (2, 4);
-
-SET REFERENTIAL_INTEGRITY TRUE;
+INSERT INTO balance_vote (balance_option_id, member_id)
+VALUES (4, 1),
+       (4, 2),
+       (4, 3),
+       (4, 4),
+       (1, 1),
+       (1, 2),
+       (1, 3),
+       (2, 4);


### PR DESCRIPTION
## Issue Number
close #37 

## As-Is
<!-- 문제 상황 정의 -->
- 테스트간 격리 필요
- 데이터를 삽입하는 sql 스크립트에 DDL과 DML 혼재

## To-Be
<!-- 변경 사항 -->
- DB의 모든 table들을 truncate하는 extension 적용
    - controller
    - service

> `@DataJpaTest`는 제외

- sql 스크립트에서 DDL 제거 및 formatting

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="578" alt="스크린샷 2024-07-23 오전 1 38 16" src="https://github.com/user-attachments/assets/63514038-8f39-4d6d-887f-f47bf52444b8">

## (Optional) Additional Description
코드와 함께 설명을 첨부합니다

```java
public class DatabaseCleanerExtension implements BeforeEachCallback { // (1)

    @Override
    public void beforeEach(ExtensionContext extensionContext) {
        ApplicationContext context = SpringExtension.getApplicationContext(extensionContext); // (2)
        cleanup(context);
    }

    private void cleanup(ApplicationContext context) {
        EntityManager em = context.getBean(EntityManager.class); // (3)
        TransactionTemplate transactionTemplate = context.getBean(TransactionTemplate.class);

        transactionTemplate.execute(action -> { // (4)
            em.clear();
            truncateTables(em);
            return null;
        });
    }

    private void truncateTables(EntityManager em) {
        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate(); // (5)
        for (String tableName : findTableNames(em)) {
            em.createNativeQuery("TRUNCATE TABLE %s RESTART IDENTITY".formatted(tableName)).executeUpdate(); // (6)
        }
        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate(); // (7)
    }

    @SuppressWarnings("unchecked")
    private List<String> findTableNames(EntityManager em) {
        String tableSelectQuery = """
                SELECT TABLE_NAME
                FROM INFORMATION_SCHEMA.TABLES
                WHERE TABLE_SCHEMA = 'PUBLIC'
                """;
        return em.createNativeQuery(tableSelectQuery).getResultList(); // (8)
    }
}
```
- (1) 각 테스트 케이스의 `@BeforeEach` 전에 실행할 작업을 정의하는 extension 인터페이스. (재사용성 증가)
- (2) `TestContext`에서 `ApplicationContext` 추출.
- (3) `ApplicationContext` bean 객체 추출.
- (4) extension은 bean이 아니기 때문에 proxy로 동작하는 `@Transactional` 적용 불가. 따라서 `TransactionTemplate`을 사용하여 트랜잭션 제어.
    - reference: https://www.baeldung.com/spring-programmatic-transaction-management
- (5) DB 참조 무결성 비활성화. (fk에 대한 참조 무결성을 비활성화하여 참조 순서와 상관없이 테이블 truncate)
- (6) truncate DDL 실행 및 id counter 리셋.
- (7) DB 참조 무결성 다시 활성화.
- (8) 전체 테이블명 리턴.