### PR TITLE
[FEAT] 방 전체 멤버 조회

### DIFF
--- a/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentResponse.java
@@ -2,8 +2,8 @@ package ddangkong.controller.balance.content.dto;
 
 import ddangkong.controller.balance.option.dto.BalanceOptionResponse;
 import ddangkong.domain.balance.content.Category;
-import ddangkong.domain.balance.content.RoomContent;
 import ddangkong.domain.balance.option.BalanceOption;
+import ddangkong.domain.balance.room.RoomContent;
 import lombok.Builder;
 
 public record BalanceContentResponse(

--- a/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
@@ -2,12 +2,15 @@ package ddangkong.controller.balance.room;
 
 import ddangkong.controller.balance.room.dto.RoomJoinRequest;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomMembersResponse;
 import ddangkong.service.balance.room.RoomService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,5 +36,12 @@ public class RoomController {
     @PostMapping("/balances/rooms/{roomId}/members")
     public RoomJoinResponse joinRoom(@PathVariable @Positive Long roomId, @Valid @RequestBody RoomJoinRequest request) {
         return roomService.joinRoom(request.nickname(), roomId);
+    }
+
+    @GetMapping("/balances/rooms/{roomId}/members")
+    public ResponseEntity<RoomMembersResponse> getAllBalanceGameRoomMember(@Positive @PathVariable Long roomId) {
+        RoomMembersResponse response = roomService.findAllRoomMember(roomId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMemberResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMemberResponse.java
@@ -8,7 +8,7 @@ public record RoomMemberResponse(
         Boolean isMaster
 ) {
 
-    public static RoomMemberResponse fromMember(Member member) {
-        return new RoomMemberResponse(member.getId(), member.getNickname(), member.isMaster());
+    public RoomMemberResponse(Member member) {
+        this(member.getId(), member.getNickname(), member.isMaster());
     }
 }

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMemberResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMemberResponse.java
@@ -1,0 +1,14 @@
+package ddangkong.controller.balance.room.dto;
+
+import ddangkong.domain.member.Member;
+
+public record RoomMemberResponse(
+        Long memberId,
+        String nickname,
+        Boolean isMaster
+) {
+
+    public static RoomMemberResponse fromMember(Member member) {
+        return new RoomMemberResponse(member.getId(), member.getNickname(), member.isMaster());
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMembersResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomMembersResponse.java
@@ -1,0 +1,8 @@
+package ddangkong.controller.balance.room.dto;
+
+import java.util.List;
+
+public record RoomMembersResponse(
+        List<RoomMemberResponse> members
+) {
+}

--- a/backend/src/main/java/ddangkong/domain/balance/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/Room.java
@@ -1,4 +1,4 @@
-package ddangkong.domain.balance.content;
+package ddangkong.domain.balance.room;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/backend/src/main/java/ddangkong/domain/balance/room/RoomContent.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/RoomContent.java
@@ -1,6 +1,8 @@
-package ddangkong.domain.balance.content;
+package ddangkong.domain.balance.room;
 
 import ddangkong.domain.BaseEntity;
+import ddangkong.domain.balance.content.BalanceContent;
+import ddangkong.domain.balance.content.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend/src/main/java/ddangkong/domain/balance/room/RoomContentRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/RoomContentRepository.java
@@ -1,4 +1,4 @@
-package ddangkong.domain.balance.content;
+package ddangkong.domain.balance.room;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/ddangkong/domain/balance/room/RoomRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/RoomRepository.java
@@ -1,4 +1,4 @@
-package ddangkong.domain.balance.content;
+package ddangkong.domain.balance.room;
 
 import ddangkong.exception.BadRequestException;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/ddangkong/domain/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/member/Member.java
@@ -29,6 +29,7 @@ public class Member {
     @JoinColumn(name = "room_id", nullable = false)
     private Room room;
 
+    @Column(nullable = false)
     private boolean isMaster;
 
     private Member(String nickname, Room room, boolean isMaster) {
@@ -40,6 +41,7 @@ public class Member {
     public static Member createMaster(String nickname, Room room) {
         return new Member(nickname, room, true);
     }
+
     public static Member createCommon(String nickname, Room room) {
         return new Member(nickname, room, false);
     }

--- a/backend/src/main/java/ddangkong/domain/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/member/Member.java
@@ -1,6 +1,6 @@
 package ddangkong.domain.member;
 
-import ddangkong.domain.balance.content.Room;
+import ddangkong.domain.balance.room.Room;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend/src/main/java/ddangkong/domain/member/MemberRepository.java
+++ b/backend/src/main/java/ddangkong/domain/member/MemberRepository.java
@@ -1,6 +1,10 @@
 package ddangkong.domain.member;
 
+import ddangkong.domain.balance.room.Room;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    List<Member> findByRoom(Room room);
 }

--- a/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
+++ b/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
@@ -2,12 +2,12 @@ package ddangkong.service.balance.content;
 
 import ddangkong.controller.balance.content.dto.BalanceContentResponse;
 import ddangkong.domain.balance.content.BalanceContent;
-import ddangkong.domain.balance.content.Room;
-import ddangkong.domain.balance.content.RoomContent;
-import ddangkong.domain.balance.content.RoomContentRepository;
-import ddangkong.domain.balance.content.RoomRepository;
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.balance.option.BalanceOptionRepository;
+import ddangkong.domain.balance.room.Room;
+import ddangkong.domain.balance.room.RoomContent;
+import ddangkong.domain.balance.room.RoomContentRepository;
+import ddangkong.domain.balance.room.RoomRepository;
 import ddangkong.exception.BadRequestException;
 import ddangkong.exception.InternalServerException;
 import java.util.List;

--- a/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
+++ b/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
@@ -40,8 +40,7 @@ public class BalanceContentService {
     }
 
     private RoomContent findCurrentRoomContent(Long roomId) {
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new BadRequestException("해당 방이 존재하지 않습니다."));
+        Room room = roomRepository.getById(roomId);
         return roomContentRepository.findByRoomAndRound(room, room.getCurrentRound())
                 .orElseThrow(() -> new BadRequestException("해당 방의 현재 진행중인 질문이 존재하지 않습니다."));
     }

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -17,9 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RoomService {
 
-    private final MemberRepository memberRepository;
-
     private final RoomRepository roomRepository;
+
+    private final MemberRepository memberRepository;
 
     @Transactional
     public RoomJoinResponse createRoom(String nickname) {

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -2,10 +2,13 @@ package ddangkong.service.balance.room;
 
 import ddangkong.controller.balance.member.dto.MemberResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
-import ddangkong.domain.balance.content.Room;
-import ddangkong.domain.balance.content.RoomRepository;
+import ddangkong.controller.balance.room.dto.RoomMemberResponse;
+import ddangkong.controller.balance.room.dto.RoomMembersResponse;
+import ddangkong.domain.balance.room.Room;
+import ddangkong.domain.balance.room.RoomRepository;
 import ddangkong.domain.member.Member;
 import ddangkong.domain.member.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,5 +33,15 @@ public class RoomService {
         Room room = roomRepository.getById(roomId);
         Member member = memberRepository.save(Member.createCommon(nickname, room));
         return new RoomJoinResponse(room.getId(), new MemberResponse(member));
+    }
+
+    @Transactional(readOnly = true)
+    public RoomMembersResponse findAllRoomMember(Long roomId) {
+        Room room = roomRepository.getById(roomId);
+
+        List<RoomMemberResponse> response = memberRepository.findByRoom(room).stream()
+                .map(RoomMemberResponse::fromMember)
+                .toList();
+        return new RoomMembersResponse(response);
     }
 }

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -39,7 +39,8 @@ public class RoomService {
     public RoomMembersResponse findAllRoomMember(Long roomId) {
         Room room = roomRepository.getById(roomId);
 
-        List<RoomMemberResponse> response = memberRepository.findByRoom(room).stream()
+        List<RoomMemberResponse> response = memberRepository.findByRoom(room)
+                .stream()
                 .map(RoomMemberResponse::new)
                 .toList();
         return new RoomMembersResponse(response);

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -40,7 +40,7 @@ public class RoomService {
         Room room = roomRepository.getById(roomId);
 
         List<RoomMemberResponse> response = memberRepository.findByRoom(room).stream()
-                .map(RoomMemberResponse::fromMember)
+                .map(RoomMemberResponse::new)
                 .toList();
         return new RoomMembersResponse(response);
     }

--- a/backend/src/test/java/ddangkong/controller/balance/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/balance/room/RoomControllerTest.java
@@ -1,14 +1,15 @@
 package ddangkong.controller.balance.room;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ddangkong.controller.BaseControllerTest;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomMembersResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -91,6 +92,24 @@ class RoomControllerTest extends BaseControllerTest {
                     .extract().as(RoomJoinResponse.class);
 
             assertThat(actual.member().isMaster()).isFalse();
+
+        }
+    }
+
+    @Nested
+    class 밸런스_게임_방_전체_멤버_조회 {
+
+        @Test
+        void 게임_방_전체_멤버_조회() {
+            //when
+            RoomMembersResponse actual = RestAssured.given()
+                    .when().get("/api/balances/rooms/1/members")
+                    .then().contentType(ContentType.JSON).log().all()
+                    .statusCode(200)
+                    .extract().as(RoomMembersResponse.class);
+
+            //then
+            Assertions.assertThat(actual.members()).hasSize(4);
         }
     }
 }

--- a/backend/src/test/java/ddangkong/domain/balance/content/RoomContentRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/domain/balance/content/RoomContentRepositoryTest.java
@@ -3,6 +3,10 @@ package ddangkong.domain.balance.content;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ddangkong.domain.BaseRepositoryTest;
+import ddangkong.domain.balance.room.Room;
+import ddangkong.domain.balance.room.RoomContent;
+import ddangkong.domain.balance.room.RoomContentRepository;
+import ddangkong.domain.balance.room.RoomRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/ddangkong/domain/balance/room/RoomContentRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/domain/balance/room/RoomContentRepositoryTest.java
@@ -1,12 +1,8 @@
-package ddangkong.domain.balance.content;
+package ddangkong.domain.balance.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ddangkong.domain.BaseRepositoryTest;
-import ddangkong.domain.balance.room.Room;
-import ddangkong.domain.balance.room.RoomContent;
-import ddangkong.domain.balance.room.RoomContentRepository;
-import ddangkong.domain.balance.room.RoomRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/ddangkong/service/balance/room/RoomServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/balance/room/RoomServiceTest.java
@@ -7,6 +7,8 @@ import ddangkong.controller.balance.member.dto.MemberResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
 import ddangkong.exception.BadRequestException;
 import ddangkong.service.BaseServiceTest;
+import ddangkong.controller.balance.room.dto.RoomMembersResponse;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +63,22 @@ class RoomServiceTest extends BaseServiceTest {
             // when & then
             assertThatThrownBy(() -> roomService.joinRoom(nickname, nonExistId))
                     .isInstanceOf(BadRequestException.class);
+        }
+    }
+
+    @Nested
+    class 게임_방_전체_멤버_조회 {
+
+        @Test
+        void 게임_방_전쳬_멤버_조회() {
+            // given
+            Long roomId = 1L;
+
+            // when
+            RoomMembersResponse actual = roomService.findAllRoomMember(roomId);
+
+            // then
+            Assertions.assertThat(actual.members()).hasSize(4);
         }
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -8,6 +8,7 @@ spring:
         highlight_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
 
 ---
 spring:
@@ -18,10 +19,6 @@ spring:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     username: sa
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
   jpa:
     hibernate:
       ddl-auto: create

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -1,5 +1,6 @@
 INSERT INTO room (total_round, current_round)
-VALUES (5, 2), (5, 1);
+VALUES (5, 2),
+       (5, 1);
 
 INSERT INTO member (nickname, room_id, is_master)
 VALUES ('mohamedeu al katan', 1, true),


### PR DESCRIPTION
## Issue Number
#62 

## As-Is
<!-- 문제 상황 정의 -->
실시간으로 방의 대기 멤버 상태를 확인하기 위한 API가 필요하다.

## To-Be
<!-- 변경 사항 -->
밸런스 게임 대기방의 전체 멤버를 조회하는 API를 구현하였다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="343" alt="image" src="https://github.com/user-attachments/assets/2a9bd9cd-105b-42a1-bc44-9a2cb3b5614a">
<img width="816" alt="스크린샷 2024-07-24 16 17 20" src="https://github.com/user-attachments/assets/b309e827-6610-4305-821c-6e6faf9d0ae4">

## (Optional) Additional Description
