### PR TITLE
[FEAT]: 선택지별 투표 결과 조회 API 구현

### DIFF
--- a/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentGroupResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentGroupResponse.java
@@ -1,0 +1,9 @@
+package ddangkong.controller.balance.content.dto;
+
+import ddangkong.controller.balance.option.dto.BalanceOptionGroupResponse;
+
+public record BalanceContentGroupResponse(
+        BalanceOptionGroupResponse firstOption,
+        BalanceOptionGroupResponse secondOption
+) {
+}

--- a/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentTotalResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/content/dto/BalanceContentTotalResponse.java
@@ -1,0 +1,9 @@
+package ddangkong.controller.balance.content.dto;
+
+import ddangkong.controller.balance.option.dto.BalanceOptionTotalResponse;
+
+public record BalanceContentTotalResponse(
+        BalanceOptionTotalResponse firstOption,
+        BalanceOptionTotalResponse secondOption
+) {
+}

--- a/backend/src/main/java/ddangkong/controller/balance/option/dto/BalanceOptionGroupResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/option/dto/BalanceOptionGroupResponse.java
@@ -1,0 +1,26 @@
+package ddangkong.controller.balance.option.dto;
+
+import ddangkong.domain.balance.option.BalanceOption;
+import ddangkong.domain.balance.vote.BalanceVote;
+import java.util.List;
+
+public record BalanceOptionGroupResponse(
+        Long optionId,
+        String name,
+        List<String> members,
+        int memberCount,
+        int percent
+) {
+    public static BalanceOptionGroupResponse of(BalanceOption balanceOption,
+                                                List<BalanceVote> balanceVotes,
+                                                int totalSize) {
+        List<String> members = balanceVotes.stream()
+                .map(BalanceVote::getMemberNickname)
+                .toList();
+        return new BalanceOptionGroupResponse(balanceOption.getId(),
+                balanceOption.getName(),
+                members,
+                balanceVotes.size(),
+                (int) Math.round(balanceVotes.size() * 1.0 / totalSize * 100));
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/balance/option/dto/BalanceOptionTotalResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/option/dto/BalanceOptionTotalResponse.java
@@ -1,0 +1,17 @@
+package ddangkong.controller.balance.option.dto;
+
+import ddangkong.domain.balance.option.BalanceOption;
+
+public record BalanceOptionTotalResponse(
+        Long optionId,
+        String name,
+        int percent
+) {
+    public static BalanceOptionTotalResponse of(BalanceOption balanceOption,
+                                                Long totalSize,
+                                                Long optionSize) {
+        return new BalanceOptionTotalResponse(balanceOption.getId(),
+                balanceOption.getName(),
+                (int) Math.round(optionSize * 1.0 / totalSize * 100));
+    }
+}

--- a/backend/src/main/java/ddangkong/controller/balance/vote/BalanceVoteController.java
+++ b/backend/src/main/java/ddangkong/controller/balance/vote/BalanceVoteController.java
@@ -1,5 +1,6 @@
 package ddangkong.controller.balance.vote;
 
+import ddangkong.controller.balance.vote.dto.BalanceVoteResultResponse;
 import ddangkong.controller.balance.vote.dto.BalanceVoteRequest;
 import ddangkong.controller.balance.vote.dto.BalanceVoteResponse;
 import ddangkong.service.balance.vote.BalanceVoteService;
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class BalanceVoteController {
 
     private final BalanceVoteService balanceVoteService;
+
+    @GetMapping("/balances/rooms/{roomId}/contents/{contentId}/vote-result")
+    public BalanceVoteResultResponse getBalanceRoundResult(@PathVariable @Positive Long roomId,
+                                                           @PathVariable @Positive Long contentId) {
+        return balanceVoteService.findBalanceVoteResult(roomId, contentId);
+    }
 
     @PostMapping("/balances/rooms/{roomId}/contents/{contentId}/votes")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/ddangkong/controller/balance/vote/dto/BalanceVoteResultResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/vote/dto/BalanceVoteResultResponse.java
@@ -7,5 +7,4 @@ public record BalanceVoteResultResponse(
         BalanceContentGroupResponse group,
         BalanceContentTotalResponse total
 ) {
-
 }

--- a/backend/src/main/java/ddangkong/controller/balance/vote/dto/BalanceVoteResultResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/vote/dto/BalanceVoteResultResponse.java
@@ -1,0 +1,11 @@
+package ddangkong.controller.balance.vote.dto;
+
+import ddangkong.controller.balance.content.dto.BalanceContentGroupResponse;
+import ddangkong.controller.balance.content.dto.BalanceContentTotalResponse;
+
+public record BalanceVoteResultResponse(
+        BalanceContentGroupResponse group,
+        BalanceContentTotalResponse total
+) {
+
+}

--- a/backend/src/main/java/ddangkong/domain/balance/content/BalanceContentRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/BalanceContentRepository.java
@@ -1,0 +1,13 @@
+package ddangkong.domain.balance.content;
+
+import ddangkong.domain.balance.option.BalanceOption;
+import ddangkong.exception.BadRequestException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BalanceContentRepository extends JpaRepository<BalanceContent, Long> {
+
+    default BalanceContent getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new BadRequestException("해당 질문 컨텐츠가 존재하지 않습니다."));
+    }
+}

--- a/backend/src/main/java/ddangkong/domain/balance/option/BalanceOptionRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/option/BalanceOptionRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BalanceOptionRepository extends JpaRepository<BalanceOption, Long> {
 
-    List<BalanceOption> findByBalanceContent(BalanceContent balanceContent);
+    List<BalanceOption> findAllByBalanceContent(BalanceContent balanceContent);
 
     default BalanceOption getById(Long id) {
         return findById(id)

--- a/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVote.java
+++ b/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVote.java
@@ -38,4 +38,8 @@ public class BalanceVote {
     public Long getOptionId() {
         return balanceOption.getId();
     }
+
+    public String getMemberNickname() {
+        return member.getNickname();
+    }
 }

--- a/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVoteRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVoteRepository.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BalanceVoteRepository extends JpaRepository<BalanceVote, Long> {
-    //    List<BalanceVote> findAllByBalanceOption(BalanceOption balanceOption);
     Long countByBalanceOption(BalanceOption balanceOption);
 
     List<BalanceVote> findByMemberRoomAndBalanceOption(Room room, BalanceOption balanceOption);

--- a/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVoteRepository.java
+++ b/backend/src/main/java/ddangkong/domain/balance/vote/BalanceVoteRepository.java
@@ -1,6 +1,13 @@
 package ddangkong.domain.balance.vote;
 
+import ddangkong.domain.balance.option.BalanceOption;
+import ddangkong.domain.balance.room.Room;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BalanceVoteRepository extends JpaRepository<BalanceVote, Long> {
+    //    List<BalanceVote> findAllByBalanceOption(BalanceOption balanceOption);
+    Long countByBalanceOption(BalanceOption balanceOption);
+
+    List<BalanceVote> findByMemberRoomAndBalanceOption(Room room, BalanceOption balanceOption);
 }

--- a/backend/src/main/java/ddangkong/domain/member/MemberRepository.java
+++ b/backend/src/main/java/ddangkong/domain/member/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    List<Member> findByRoom(Room room);
+    List<Member> findAllByRoom(Room room);
 
     default Member getById(Long id) {
         return findById(id)

--- a/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
+++ b/backend/src/main/java/ddangkong/service/balance/content/BalanceContentService.java
@@ -46,7 +46,7 @@ public class BalanceContentService {
     }
 
     private List<BalanceOption> findBalanceOptions(BalanceContent balanceContent) {
-        List<BalanceOption> balanceOptions = balanceOptionRepository.findByBalanceContent(balanceContent);
+        List<BalanceOption> balanceOptions = balanceOptionRepository.findAllByBalanceContent(balanceContent);
         validateBalanceOptions(balanceOptions);
         return balanceOptions;
     }

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -39,7 +39,7 @@ public class RoomService {
     public RoomMembersResponse findAllRoomMember(Long roomId) {
         Room room = roomRepository.getById(roomId);
 
-        List<RoomMemberResponse> response = memberRepository.findByRoom(room)
+        List<RoomMemberResponse> response = memberRepository.findAllByRoom(room)
                 .stream()
                 .map(RoomMemberResponse::new)
                 .toList();

--- a/backend/src/main/java/ddangkong/service/balance/vote/BalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/balance/vote/BalanceVoteService.java
@@ -1,14 +1,28 @@
 package ddangkong.service.balance.vote;
 
+import ddangkong.controller.balance.content.dto.BalanceContentGroupResponse;
+import ddangkong.controller.balance.content.dto.BalanceContentTotalResponse;
+import ddangkong.controller.balance.option.dto.BalanceOptionGroupResponse;
+import ddangkong.controller.balance.option.dto.BalanceOptionTotalResponse;
+import ddangkong.controller.balance.vote.dto.BalanceVoteResultResponse;
 import ddangkong.controller.balance.vote.dto.BalanceVoteRequest;
 import ddangkong.controller.balance.vote.dto.BalanceVoteResponse;
+import ddangkong.domain.balance.content.BalanceContent;
+import ddangkong.domain.balance.content.BalanceContentRepository;
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.balance.option.BalanceOptionRepository;
+import ddangkong.domain.balance.room.Room;
+import ddangkong.domain.balance.room.RoomContent;
+import ddangkong.domain.balance.room.RoomContentRepository;
+import ddangkong.domain.balance.room.RoomRepository;
 import ddangkong.domain.balance.vote.BalanceVote;
 import ddangkong.domain.balance.vote.BalanceVoteRepository;
 import ddangkong.domain.member.Member;
 import ddangkong.domain.member.MemberRepository;
 import ddangkong.exception.BadRequestException;
+import ddangkong.exception.InternalServerException;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +31,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BalanceVoteService {
 
+    private static final int BALANCE_OPTION_SIZE = 2;
+
     private final BalanceVoteRepository balanceVoteRepository;
 
     private final MemberRepository memberRepository;
 
     private final BalanceOptionRepository balanceOptionRepository;
+
+    private final BalanceContentRepository balanceContentRepository;
+
+    private final RoomContentRepository roomContentRepository;
+
+    private final RoomRepository roomRepository;
 
     @Transactional
     public BalanceVoteResponse createBalanceVote(BalanceVoteRequest request, Long roomId, Long contentId) {
@@ -51,5 +73,71 @@ public class BalanceVoteService {
             throw new BadRequestException(errorMessage);
         }
         return member;
+    }
+
+    @Transactional(readOnly = true)
+    public BalanceVoteResultResponse findBalanceVoteResult(Long roomId, Long balanceContentId) {
+        Room room = roomRepository.getById(roomId);
+        List<BalanceOption> balanceOptions = findBalanceOptions(room, balanceContentId);
+
+        BalanceOption firstOption = balanceOptions.get(0);
+        BalanceOption secondOption = balanceOptions.get(1);
+
+        BalanceContentGroupResponse group = getBalanceContentGroupResponse(room, firstOption, secondOption);
+        BalanceContentTotalResponse total = getBalanceContentTotalResponse(firstOption, secondOption);
+
+        return new BalanceVoteResultResponse(group, total);
+    }
+
+    private BalanceContentGroupResponse getBalanceContentGroupResponse(Room room,
+                                                                       BalanceOption firstOption,
+                                                                       BalanceOption secondOption) {
+        List<BalanceVote> firstOptionVotes = balanceVoteRepository
+                .findByMemberRoomAndBalanceOption(room, firstOption);
+        List<BalanceVote> secondOptionVotes = balanceVoteRepository
+                .findByMemberRoomAndBalanceOption(room, secondOption);
+
+        int roomMemberSize = firstOptionVotes.size() + secondOptionVotes.size();
+        return new BalanceContentGroupResponse(
+                BalanceOptionGroupResponse.of(firstOption, firstOptionVotes, roomMemberSize),
+                BalanceOptionGroupResponse.of(secondOption, secondOptionVotes, roomMemberSize)
+        );
+    }
+
+    private BalanceContentTotalResponse getBalanceContentTotalResponse(BalanceOption firstOption,
+                                                                       BalanceOption secondOption) {
+        Long firstOptionCount = balanceVoteRepository.countByBalanceOption(firstOption);
+        Long secondOptionCount = balanceVoteRepository.countByBalanceOption(secondOption);
+        return new BalanceContentTotalResponse(
+                BalanceOptionTotalResponse.of(firstOption,
+                        firstOptionCount + secondOptionCount,
+                        firstOptionCount),
+                BalanceOptionTotalResponse.of(secondOption,
+                        firstOptionCount + secondOptionCount,
+                        secondOptionCount)
+        );
+    }
+
+    private List<BalanceOption> findBalanceOptions(Room room, Long balanceContentId) {
+        RoomContent roomContent = roomContentRepository.findByRoomAndRound(room, room.getCurrentRound())
+                .orElseThrow(() -> new BadRequestException("해당 방의 현재 진행중인 질문이 존재하지 않습니다."));
+        validateBalanceContent(balanceContentId, roomContent.getBalanceContent());
+
+        BalanceContent balanceContent = balanceContentRepository.getById(balanceContentId);
+        List<BalanceOption> balanceOptions = balanceOptionRepository.findAllByBalanceContent(balanceContent);
+        validateBalanceOptions(balanceOptions);
+        return balanceOptions;
+    }
+
+    private void validateBalanceContent(Long balanceContentId, BalanceContent balanceContent) {
+        if (!Objects.equals(balanceContent.getId(), balanceContentId)) {
+            throw new BadRequestException("현재 진행중인 질문의 컨텐츠와 일치하지 않는 요청입니다.");
+        }
+    }
+
+    private void validateBalanceOptions(List<BalanceOption> balanceOptions) {
+        if (balanceOptions.size() != BALANCE_OPTION_SIZE) {
+            throw new InternalServerException("밸런스 게임의 선택지가 %d개입니다".formatted(balanceOptions.size()));
+        }
     }
 }

--- a/backend/src/test/java/ddangkong/service/balance/content/BalanceContentServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/balance/content/BalanceContentServiceTest.java
@@ -21,7 +21,7 @@ class BalanceContentServiceTest extends BaseServiceTest {
     class 현재_방의_밸런스_게임_내용_조회 {
 
         private static final Long PROGRESS_ROOM_ID = 1L;
-        private static final Long NOT_EXIST_ROOM_ID = 3L;
+        private static final Long NOT_EXIST_ROOM_ID = 99999999L;
         private static final Long NOT_PROGRESSED_ROOM_ID = 2L;
         private static final BalanceContentResponse BALANCE_CONTENT_RESPONSE = new BalanceContentResponse(
                 1L, Category.EXAMPLE, 5, 2, "민초 vs 반민초",

--- a/backend/src/test/java/ddangkong/service/balance/room/RoomServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/balance/room/RoomServiceTest.java
@@ -25,8 +25,8 @@ class RoomServiceTest extends BaseServiceTest {
         void 방_생성_시_멤버를_생성하고_방을_생성한다() {
             // given
             String nickname = "나는방장";
-            MemberResponse expectedMemberResponse = new MemberResponse(5L, nickname, true);
-            RoomJoinResponse expected = new RoomJoinResponse(3L, expectedMemberResponse);
+            MemberResponse expectedMemberResponse = new MemberResponse(7L, nickname, true);
+            RoomJoinResponse expected = new RoomJoinResponse(4L, expectedMemberResponse);
 
             // when
             RoomJoinResponse actual = roomService.createRoom(nickname);
@@ -44,7 +44,7 @@ class RoomServiceTest extends BaseServiceTest {
             // given
             String nickname = "나는참가자";
             Long joinRoomId = 2L;
-            MemberResponse expectedMemberResponse = new MemberResponse(5L, nickname, false);
+            MemberResponse expectedMemberResponse = new MemberResponse(7L, nickname, false);
             RoomJoinResponse expected = new RoomJoinResponse(joinRoomId, expectedMemberResponse);
 
             // when

--- a/backend/src/test/java/ddangkong/service/balance/vote/BalanceVoteServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/balance/vote/BalanceVoteServiceTest.java
@@ -3,10 +3,16 @@ package ddangkong.service.balance.vote;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ddangkong.controller.balance.content.dto.BalanceContentGroupResponse;
+import ddangkong.controller.balance.content.dto.BalanceContentTotalResponse;
+import ddangkong.controller.balance.option.dto.BalanceOptionGroupResponse;
+import ddangkong.controller.balance.option.dto.BalanceOptionTotalResponse;
 import ddangkong.controller.balance.vote.dto.BalanceVoteRequest;
 import ddangkong.controller.balance.vote.dto.BalanceVoteResponse;
+import ddangkong.controller.balance.vote.dto.BalanceVoteResultResponse;
 import ddangkong.exception.BadRequestException;
 import ddangkong.service.BaseServiceTest;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,5 +71,43 @@ class BalanceVoteServiceTest extends BaseServiceTest {
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("해당 방의 멤버가 아닙니다. roomId : 2, memberId : 1");
         }
+    }
+
+    @Nested
+    class 투표_결과_조회 {
+
+        @Test
+        void 투표_결과를_조회한다() {
+            // given
+            BalanceVoteResultResponse expected = new BalanceVoteResultResponse(
+                    new BalanceContentGroupResponse(
+                            new BalanceOptionGroupResponse(1L,
+                                    "민초",
+                                    List.of("mohamedeu al katan", "deundeun", "rupi"),
+                                    3, 75),
+                            new BalanceOptionGroupResponse(2L,
+                                    "반민초",
+                                    List.of("rapper lee"), 1, 25)
+                    ),
+                    new BalanceContentTotalResponse(
+                            new BalanceOptionTotalResponse(1L, "민초", 50),
+                            new BalanceOptionTotalResponse(2L, "반민초", 50)
+                    )
+            );
+
+            // when
+            BalanceVoteResultResponse actual = balanceVoteService.findBalanceVoteResult(1L, 1L);
+
+            // then
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void 진행중인_주제가_아닌것의_투표_결과를_요청하면_예외를_발생시킨다() {
+            // when & then
+            assertThatThrownBy(() -> balanceVoteService.findBalanceVoteResult(1L, 2L))
+                    .isInstanceOf(BadRequestException.class);
+        }
+
     }
 }

--- a/backend/src/test/java/ddangkong/service/balance/vote/BalanceVoteServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/balance/vote/BalanceVoteServiceTest.java
@@ -108,6 +108,5 @@ class BalanceVoteServiceTest extends BaseServiceTest {
             assertThatThrownBy(() -> balanceVoteService.findBalanceVoteResult(1L, 2L))
                     .isInstanceOf(BadRequestException.class);
         }
-
     }
 }

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -1,12 +1,15 @@
 INSERT INTO room (total_round, current_round)
 VALUES (5, 2),
+       (5, 1),
        (5, 1);
 
 INSERT INTO member (nickname, room_id, is_master)
 VALUES ('mohamedeu al katan', 1, true),
        ('deundeun', 1, false),
        ('rupi', 1, false),
-       ('rapper lee', 1, false);
+       ('rapper lee', 1, false),
+       ('alpha', 2, true),
+       ('bravo', 2, false);
 
 INSERT INTO balance_content (category, name)
 VALUES ('EXAMPLE', '민초 vs 반민초'),
@@ -14,7 +17,8 @@ VALUES ('EXAMPLE', '민초 vs 반민초'),
 
 INSERT INTO room_content (room_id, balance_content_id, round, created_at)
 VALUES (1, 2, 1, '2024-07-18 19:50:00.000'),
-       (1, 1, 2, '2024-07-18 20:00:00.000');
+       (1, 1, 2, '2024-07-18 20:00:00.000'),
+       (3, 1, 1, '2024-07-18 19:51:00.000');
 
 INSERT INTO balance_option (name, balance_content_id)
 VALUES ('민초', 1),
@@ -27,6 +31,9 @@ VALUES (4, 1),
        (4, 2),
        (4, 3),
        (4, 4),
+       (1, 1),
        (1, 2),
        (1, 3),
-       (2, 4);
+       (2, 4),
+       (2, 5),
+       (2, 6);


### PR DESCRIPTION
## Issue Number
#68  

## As-Is
<!-- 문제 상황 정의 -->
참가자의 투표 결과 및 전체 사용자의 투표 통계를 조회하는 기능을 제공한다.

## To-Be
<!-- 변경 사항 -->
- 투표 결과 조회 API 추가
- 투표 결과를 전달해주기 위한 DTO들 추기
- 관련 테스트 및 테스트 데이터 추가


## Check List
- [X] 테스트가 전부 통과되었나요?
- [X] 모든 commit이 push 되었나요?
- [X] merge할 branch를 확인했나요?
- [X] Assignee를 지정했나요?
- [X] Label을 지정했나요?

## Test Screenshot
<img width="699" alt="image" src="https://github.com/user-attachments/assets/1ee1f3f5-27d5-452b-aeaa-340e04204df5">


## (Optional) Additional Description
자꾸 커밋할 때 이슈 번호 까먹는데 주의하겠습니다! 🙇‍♂️