### PR TITLE
[FIX] CD `docker image pull` 과정에서 멈춤 현상 해결

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -75,18 +75,18 @@ jobs:
         run: |
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
           if [ -n ${CONTAINER_ID} ]; then
-            sudo docker rm -f ${CONTAINER_ID}
+          sudo docker rm -f ${CONTAINER_ID}
           else
-            echo "No previous container found with name. Skipping removal."
+          echo "No previous container found with name. Skipping removal."
           fi
 
       - name: Remove previous Docker image
         run: |    
           IMAGE_ID=$(sudo docker images --filter=reference=ddangkong/ddangkong-api-dev --format "{{.ID}}")
           if [ -n ${IMAGE_ID} ]; then
-            sudo docker rmi ${IMAGE_ID}
+          sudo docker rmi ${IMAGE_ID}
           else
-            echo "No previous image found with repository name. Skipping removal."
+          echo "No previous image found with repository name. Skipping removal."
           fi
 
       - name: Run new Docker container

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -73,9 +73,18 @@ jobs:
         run: |
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
           if [ -n ${CONTAINER_ID} ]; then
-          sudo docker rm -f ${CONTAINER_ID}
+            sudo docker rm -f ${CONTAINER_ID}
           else
             echo "No previous container found with name. Skipping removal."
+          fi
+
+      - name: Remove previous Docker image
+        run: |    
+          IMAGE_ID=$(sudo docker images --filter=reference=ddangkong/ddangkong-api-dev --format "{{.ID}}")
+          if [ -n ${IMAGE_ID} ]; then
+            sudo docker rmi ${IMAGE_ID}
+          else
+            echo "No previous image found with repository name. Skipping removal."
           fi
 
       - name: Run new Docker container

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     env:
       DOCKER_REPOSITORY_NAME: ddangkong/ddangkong-api-dev
@@ -54,6 +55,7 @@ jobs:
 
   deploy:
     needs: build
+    timeout-minutes: 1
     runs-on: [ self-hosted, linux, ARM64 ] # Self hosted runner 사용
     env:
       DOCKER_REPOSITORY_NAME: ddangkong/ddangkong-api-dev

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -68,9 +68,6 @@ jobs:
           username: ${{ secrets.DOCKER_GMAIL }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Pull docker image
-        run: sudo docker pull $DOCKER_REPOSITORY_NAME:latest
-
       - name: Stop and Remove previous Docker container
         run: |
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
@@ -88,6 +85,9 @@ jobs:
           else
           echo "No previous image found with repository name. Skipping removal."
           fi
+
+      - name: Pull docker image
+        run: sudo docker pull $DOCKER_REPOSITORY_NAME:latest
 
       - name: Run new Docker container
         run: |

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Stop and Remove previous Docker container
         run: |
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
-          if [ -n ${CONTAINER_ID} ]; then
+          if [ -n "${CONTAINER_ID}" ]; then
           sudo docker rm -f ${CONTAINER_ID}
           else
           echo "No previous container found with name. Skipping removal."
@@ -80,7 +80,7 @@ jobs:
       - name: Remove previous Docker image
         run: |    
           IMAGE_ID=$(sudo docker images --filter=reference=ddangkong/ddangkong-api-dev --format "{{.ID}}")
-          if [ -n ${IMAGE_ID} ]; then
+          if [ -n "${IMAGE_ID}" ]; then
           sudo docker rmi ${IMAGE_ID}
           else
           echo "No previous image found with repository name. Skipping removal."

--- a/.github/workflows/be-ci-dev.yml
+++ b/.github/workflows/be-ci-dev.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 4
     runs-on: ubuntu-latest
 
     defaults:


### PR DESCRIPTION
## Issue Number
#100

## As-Is
<!-- 문제 상황 정의 -->
CD docker image pull 과정에서 발생하는 멈춤 현상 발생

- 문제 해결을 위해 확인해본 결과, 기존 버전의 이미지를 모두 삭제하니 정상적으로 작동하는 것을 확인하여
기존 이미지 삭제 스크립트 추가하는 방향으로 해결
- 또한 스크립트가 긴 시간동안 종료되지 않아도 계속해서 돌아가기 때문에 타임아웃을 통해 적절히 끊어줄 필요성을 느낌

<img width="815" alt="스크린샷 2024-08-01 14 01 00" src="https://github.com/user-attachments/assets/c596fac1-583d-4197-9292-ecd11d943294">
<img width="342" alt="스크린샷 2024-08-01 14 20 11" src="https://github.com/user-attachments/assets/31b135e0-00f9-4a88-8046-21987c3a9421">

## To-Be
<!-- 변경 사항 -->

### CD 스크립트에 기존 사용되던 도커 이미지 삭제하는 코드 추가
[커밋 내용](https://github.com/woowacourse-teams/2024-ddangkong/pull/104/commits/40dbafcde81acf02e12c59b71bad70d45360364d)

### 스크립트 제한시간 설정
[커밋 내용](https://github.com/woowacourse-teams/2024-ddangkong/pull/104/commits/13e0a328bbc350a09a79fc7c3d91486285ec101c)

- CI - 4분
  - 약 100개의 CI 스크립트 동작 시간 중 1분 50초가 최대 시간이었음. 때문에 현재 소요되는 시간의 2배인 4분을 넘는 순간 문제가 생긴 것으로 간주

- CD - 4분 
  - 125개의 CD 스크립트의
    - build job 동작 시간 중 1분 33초가 최대 시간이었음. 때문에 현재 소요되는 시간의 약 2배인 3분을 넘는 순간 문제가 생긴 것으로 간주
    - deploy job 동작 시간 중 21초가 최대 시간이었음. 때문에 현재 소요되는 시간의 약 2배인 1분을 넘는 순간 문제가 생긴 것으로 간주

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/e45c1560-2fb3-4163-80fe-bf3749717c36">


## (Optional) Additional Description
