### PR TITLE
[FEAT] 방 설정 정보 변경 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/room.adoc
+++ b/backend/src/docs/asciidoc/room.adoc
@@ -85,3 +85,23 @@ include::{snippets}/room/next/http-response.adoc[]
 response fields
 
 include::{snippets}/room/next/response-fields.adoc[]
+
+=== 방 설정 변경
+
+==== curl
+
+include::{snippets}/room/setting/curl-request.adoc[]
+
+==== request
+
+include::{snippets}/room/setting/http-request.adoc[]
+
+include::{snippets}/room/setting/path-parameters.adoc[]
+
+==== response
+
+include::{snippets}/room/setting/http-response.adoc[]
+
+response fields
+
+include::{snippets}/room/setting/response-fields.adoc[]

--- a/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
@@ -28,7 +28,6 @@ public class RoomController {
 
     private final RoomService roomService;
 
-    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/balances/rooms/{roomId}")
     public RoomInfoResponse getBalanceGameRoomInfo(@Positive @PathVariable Long roomId) {
         return roomService.findRoomInfo(roomId);

--- a/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/RoomController.java
@@ -4,6 +4,7 @@ import ddangkong.controller.balance.content.dto.BalanceContentResponse;
 import ddangkong.controller.balance.room.dto.RoomInfoResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinRequest;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomSettingRequest;
 import ddangkong.service.balance.room.RoomService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +28,7 @@ public class RoomController {
 
     private final RoomService roomService;
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/balances/rooms/{roomId}")
     public RoomInfoResponse getBalanceGameRoomInfo(@Positive @PathVariable Long roomId) {
         return roomService.findRoomInfo(roomId);
@@ -47,5 +50,12 @@ public class RoomController {
     @PostMapping("/balances/rooms/{roomId}/contents")
     public BalanceContentResponse moveToNextRound(@PathVariable @Positive Long roomId) {
         return roomService.moveToNextRound(roomId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/balances/rooms/{roomId}")
+    public void updateRoomSetting(@PathVariable @Positive Long roomId,
+                                  @RequestBody RoomSettingRequest request) {
+        roomService.updateRoomSetting(roomId, request);
     }
 }

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomInfoResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomInfoResponse.java
@@ -14,7 +14,8 @@ public record RoomInfoResponse(
         List<MemberResponse> membersResponse = members.stream()
                 .map(MemberResponse::new)
                 .toList();
-        RoomSettingResponse roomSettingResponse = new RoomSettingResponse(room.getTotalRound(), room.getTimeLimit());
+        RoomSettingResponse roomSettingResponse = new RoomSettingResponse(room.getTotalRound(), room.getTimeLimit(),
+                room.getCategory());
 
         return new RoomInfoResponse(room.isGameProgress(), roomSettingResponse, membersResponse);
     }

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomSettingRequest.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomSettingRequest.java
@@ -1,0 +1,10 @@
+package ddangkong.controller.balance.room.dto;
+
+import ddangkong.domain.balance.content.Category;
+
+public record RoomSettingRequest(
+        int totalRound,
+        int timeLimit,
+        Category category
+) {
+}

--- a/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomSettingResponse.java
+++ b/backend/src/main/java/ddangkong/controller/balance/room/dto/RoomSettingResponse.java
@@ -1,7 +1,15 @@
 package ddangkong.controller.balance.room.dto;
 
+import ddangkong.domain.balance.content.Category;
+import ddangkong.domain.balance.room.Room;
+
 public record RoomSettingResponse(
         int totalRound,
-        int timeLimit
+        int timeLimit,
+        Category category
 ) {
+
+    public static RoomSettingResponse from(Room room) {
+        return new RoomSettingResponse(room.getTotalRound(), room.getTimeLimit(), room.getCategory());
+    }
 }

--- a/backend/src/main/java/ddangkong/domain/balance/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/Room.java
@@ -82,6 +82,10 @@ public class Room {
         this.totalRound = totalRound;
     }
 
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
+
     private boolean canMoveToNextRound() {
         return currentRound < totalRound;
     }

--- a/backend/src/main/java/ddangkong/domain/balance/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/Room.java
@@ -19,7 +19,10 @@ import lombok.NoArgsConstructor;
 public class Room {
 
     private static final int DEFAULT_TOTAL_ROUND = 5;
-    private static final int DEFAULT_TIME_LIMIT_MSEC = 30_000;
+    private static final int MIN_TOTAL_ROUND = 3;
+    private static final int MAX_TOTAL_ROUND = 10;
+    private static final int MIN_TIME_LIMIT_MSEC = 10_000;
+    private static final int MAX_TIME_LIMIT_MSEC = 30_000;
     private static final int START_ROUND = 1;
 
     @Id
@@ -44,7 +47,7 @@ public class Room {
     private Category category;
 
     public static Room createNewRoom() {
-        return new Room(DEFAULT_TOTAL_ROUND, START_ROUND, DEFAULT_TIME_LIMIT_MSEC, RoomStatus.READY, Category.EXAMPLE);
+        return new Room(DEFAULT_TOTAL_ROUND, START_ROUND, MAX_TIME_LIMIT_MSEC, RoomStatus.READY, Category.EXAMPLE);
     }
 
     public Room(int totalRound, int currentRound, int timeLimit, RoomStatus status, Category category) {
@@ -64,10 +67,18 @@ public class Room {
     }
 
     public void updateTimeLimit(int timeLimit) {
+        if (timeLimit < MIN_TIME_LIMIT_MSEC || timeLimit > MAX_TIME_LIMIT_MSEC) {
+            throw new BadRequestException("시간 제한은 %dms 이상, %dms 이하만 가능합니다. requested timeLimit: %d"
+                    .formatted(MIN_TIME_LIMIT_MSEC, MAX_TIME_LIMIT_MSEC, timeLimit));
+        }
         this.timeLimit = timeLimit;
     }
 
     public void updateTotalRound(int totalRound) {
+        if (totalRound < MIN_TOTAL_ROUND || totalRound > MAX_TOTAL_ROUND) {
+            throw new BadRequestException("총 라운드는 %d 이상, %d 이하만 가능합니다. requested totalRound: %d"
+                    .formatted(MIN_TOTAL_ROUND, MAX_TOTAL_ROUND, totalRound));
+        }
         this.totalRound = totalRound;
     }
 

--- a/backend/src/main/java/ddangkong/domain/balance/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/balance/room/Room.java
@@ -1,5 +1,6 @@
 package ddangkong.domain.balance.room;
 
+import ddangkong.domain.balance.content.Category;
 import ddangkong.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,15 +39,20 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
     public static Room createNewRoom() {
-        return new Room(DEFAULT_TOTAL_ROUND, START_ROUND, DEFAULT_TIME_LIMIT_MSEC, RoomStatus.READY);
+        return new Room(DEFAULT_TOTAL_ROUND, START_ROUND, DEFAULT_TIME_LIMIT_MSEC, RoomStatus.READY, Category.EXAMPLE);
     }
 
-    public Room(int totalRound, int currentRound, int timeLimit, RoomStatus status) {
+    public Room(int totalRound, int currentRound, int timeLimit, RoomStatus status, Category category) {
         this.totalRound = totalRound;
         this.currentRound = currentRound;
         this.timeLimit = timeLimit;
         this.status = status;
+        this.category = category;
     }
 
     public void moveToNextRound() {
@@ -55,6 +61,14 @@ public class Room {
             return;
         }
         throw new BadRequestException("마지막 라운드입니다.");
+    }
+
+    public void updateTimeLimit(int timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+
+    public void updateTotalRound(int totalRound) {
+        this.totalRound = totalRound;
     }
 
     private boolean canMoveToNextRound() {

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -78,5 +78,6 @@ public class RoomService {
 
         room.updateTimeLimit(request.timeLimit());
         room.updateTotalRound(request.totalRound());
+        room.updateCategory(request.category());
     }
 }

--- a/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/balance/room/RoomService.java
@@ -4,6 +4,7 @@ import ddangkong.controller.balance.content.dto.BalanceContentResponse;
 import ddangkong.controller.balance.member.dto.MemberResponse;
 import ddangkong.controller.balance.room.dto.RoomInfoResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomSettingRequest;
 import ddangkong.domain.balance.option.BalanceOptionRepository;
 import ddangkong.domain.balance.option.BalanceOptions;
 import ddangkong.domain.balance.room.Room;
@@ -69,5 +70,13 @@ public class RoomService {
     private RoomContent findCurrentRoomContent(Room room) {
         return roomContentRepository.findByRoomAndRound(room, room.getCurrentRound())
                 .orElseThrow(() -> new BadRequestException("해당 방의 현재 진행중인 질문이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void updateRoomSetting(Long roomId, RoomSettingRequest request) {
+        Room room = roomRepository.getById(roomId);
+
+        room.updateTimeLimit(request.timeLimit());
+        room.updateTotalRound(request.totalRound());
     }
 }

--- a/backend/src/main/resources/sql/data-dev.sql
+++ b/backend/src/main/resources/sql/data-dev.sql
@@ -19,8 +19,8 @@ VALUES ('민초', 1),
        ('어떻게 죽을 지 알기', 5);
 
 
-INSERT INTO room(total_round, current_round, time_limit, status)
-VALUES (5, 1, 30000, 'READY');
+INSERT INTO room(total_round, current_round, time_limit, status, category)
+VALUES (5, 1, 30000, 'READY', 'EXAMPLE');
 
 
 INSERT INTO room_content(room_id, balance_content_id, round, created_at)

--- a/backend/src/test/java/ddangkong/controller/balance/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/balance/room/RoomControllerTest.java
@@ -8,6 +8,7 @@ import ddangkong.controller.balance.content.dto.BalanceContentResponse;
 import ddangkong.controller.balance.option.dto.BalanceOptionResponse;
 import ddangkong.controller.balance.room.dto.RoomInfoResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomSettingRequest;
 import ddangkong.domain.balance.content.Category;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -16,6 +17,7 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 class RoomControllerTest extends BaseControllerTest {
 
@@ -149,6 +151,29 @@ class RoomControllerTest extends BaseControllerTest {
                     .when().post("/api/balances/rooms/{roomId}/contents")
                     .then().log().all()
                     .statusCode(400);
+        }
+    }
+
+    @Nested
+    class 방_설정_변경 {
+
+        @Test
+        void 방_설정_정보를_변경한다() {
+            // given
+            int totalRound = 5;
+            int timeLimit = 10000;
+            Category category = Category.EXAMPLE;
+
+            RoomSettingRequest request = new RoomSettingRequest(totalRound, timeLimit, category);
+
+            // when & then
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .pathParam("roomId", 1L)
+                    .body(request)
+                    .when().patch("/api/balances/rooms/{roomId}")
+                    .then().log().all()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
         }
     }
 }

--- a/backend/src/test/java/ddangkong/documentation/BaseDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/BaseDocumentationTest.java
@@ -34,7 +34,7 @@ public abstract class BaseDocumentationTest {
                         .withRequestDefaults(
                                 modifyUris()
                                         .scheme("https")
-                                        .host("ddangkong.io")
+                                        .host("ddangkong.kr")
                                         .removePort(),
                                 prettyPrint(),
                                 modifyHeaders().remove(HttpHeaders.CONTENT_LENGTH)

--- a/backend/src/test/java/ddangkong/documentation/balance/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/balance/room/RoomDocumentationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -24,6 +25,7 @@ import ddangkong.controller.balance.room.RoomController;
 import ddangkong.controller.balance.room.dto.RoomInfoResponse;
 import ddangkong.controller.balance.room.dto.RoomJoinRequest;
 import ddangkong.controller.balance.room.dto.RoomJoinResponse;
+import ddangkong.controller.balance.room.dto.RoomSettingRequest;
 import ddangkong.controller.balance.room.dto.RoomSettingResponse;
 import ddangkong.documentation.BaseDocumentationTest;
 import ddangkong.domain.balance.content.Category;
@@ -124,9 +126,10 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             //given
             int totalRound = 5;
             int timeLimit = 30000;
+            Category category = Category.EXAMPLE;
             RoomInfoResponse response = new RoomInfoResponse(
                     false,
-                    new RoomSettingResponse(totalRound, timeLimit),
+                    new RoomSettingResponse(totalRound, timeLimit, category),
                     List.of(
                             new MemberResponse(1L, "땅콩", true),
                             new MemberResponse(2L, "타콩", false)
@@ -147,6 +150,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("roomSetting").type(JsonFieldType.OBJECT).description("현재 방 설정 값"),
                                     fieldWithPath("roomSetting.totalRound").type(NUMBER).description("전체 라운드"),
                                     fieldWithPath("roomSetting.timeLimit").type(NUMBER).description("라운드 당 시간제한(ms)"),
+                                    fieldWithPath("roomSetting.category").type(STRING).description("컨텐츠 카테고리"),
                                     fieldWithPath("members").type(JsonFieldType.ARRAY).description("방에 참여중 인원 목록"),
                                     fieldWithPath("members[].memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("members[].nickname").type(STRING).description("멤버 닉네임"),
@@ -196,6 +200,37 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("firstOption.name").type(STRING).description("첫 번째 선택지명"),
                                     fieldWithPath("secondOption.optionId").type(NUMBER).description("두 번째 선택지 ID"),
                                     fieldWithPath("secondOption.name").type(STRING).description("두 번째 선택지명")
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    class 방_설정_변경 {
+
+        private static final String ENDPOINT = "/api/balances/rooms/{roomId}";
+
+        @Test
+        void 방의_설정_정보를_변경한다() throws Exception {
+            // given
+            int totalRound = 5;
+            int timeLimit = 30_000;
+            Category category = Category.EXAMPLE;
+            RoomSettingRequest content = new RoomSettingRequest(totalRound, timeLimit, category);
+
+            // then
+            mockMvc.perform(patch(ENDPOINT, 1L)
+                            .content(objectMapper.writeValueAsString(content))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent())
+                    .andDo(document("room/setting",
+                            pathParameters(
+                                    parameterWithName("roomId").description("방 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("totalRound").type(NUMBER).description("변경할 총 라운드"),
+                                    fieldWithPath("timeLimit").type(NUMBER).description("변경할 제한 시간"),
+                                    fieldWithPath("category").type(STRING).description("변경할 카테고리")
                             )
                     ));
         }

--- a/backend/src/test/java/ddangkong/domain/balance/room/RoomTest.java
+++ b/backend/src/test/java/ddangkong/domain/balance/room/RoomTest.java
@@ -3,6 +3,7 @@ package ddangkong.domain.balance.room;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ddangkong.domain.balance.content.Category;
 import ddangkong.exception.BadRequestException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class RoomTest {
             int totalRound = 5;
             int currentRound = 5;
             int timeLimit = 30000;
-            Room room = new Room(totalRound, currentRound, timeLimit, RoomStatus.PROGRESS);
+            Room room = new Room(totalRound, currentRound, timeLimit, RoomStatus.PROGRESS, Category.EXAMPLE);
 
             // when & then
             assertThatThrownBy(room::moveToNextRound)

--- a/backend/src/test/java/ddangkong/domain/balance/room/RoomTest.java
+++ b/backend/src/test/java/ddangkong/domain/balance/room/RoomTest.java
@@ -7,6 +7,8 @@ import ddangkong.domain.balance.content.Category;
 import ddangkong.exception.BadRequestException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class RoomTest {
 
@@ -40,6 +42,36 @@ class RoomTest {
             assertThatThrownBy(room::moveToNextRound)
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("마지막 라운드입니다.");
+        }
+    }
+
+    @Nested
+    class 방_설정_변경 {
+
+        @ParameterizedTest
+        @ValueSource(ints = {2, 11})
+        void 라운드는_3이상_10이하_여야한다(int notValidTotalRound) {
+            // given
+            Room room = Room.createNewRoom();
+
+            // when & then
+            assertThatThrownBy(() -> room.updateTotalRound(notValidTotalRound))
+                    .isExactlyInstanceOf(BadRequestException.class)
+                    .hasMessage("총 라운드는 %d 이상, %d 이하만 가능합니다. requested totalRound: %d"
+                            .formatted(3, 10, notValidTotalRound));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {9000, 31000})
+        void 시간_제한은_10000이상_30000이하_여야한다(int notValidTimeLimit) {
+            // given
+            Room room = Room.createNewRoom();
+
+            // when & then
+            assertThatThrownBy(() -> room.updateTimeLimit(notValidTimeLimit))
+                    .isExactlyInstanceOf(BadRequestException.class)
+                    .hasMessage("시간 제한은 %dms 이상, %dms 이하만 가능합니다. requested timeLimit: %d"
+                            .formatted(10000, 30000, notValidTimeLimit));
         }
     }
 }

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -1,7 +1,7 @@
-INSERT INTO room (total_round, current_round, time_limit, status)
-VALUES (5, 2, 30000, 'PROGRESS'),
-       (5, 1, 30000, 'PROGRESS'),
-       (5, 1, 30000, 'PROGRESS');
+INSERT INTO room (total_round, current_round, time_limit, status, category)
+VALUES (5, 2, 30000, 'PROGRESS', 'EXAMPLE'),
+       (5, 1, 30000, 'PROGRESS', 'EXAMPLE'),
+       (5, 1, 30000, 'PROGRESS', 'EXAMPLE');
 
 INSERT INTO member (nickname, room_id, is_master)
 VALUES ('mohamedeu al katan', 1, true),


### PR DESCRIPTION
## Issue Number
#107

## As-Is
<!-- 문제 상황 정의 -->
- (P2)방 설정에 필요한 API를 구현해야한다.

## To-Be
<!-- 변경 사항 -->
- Room Entity에 category필드 추가(ERD 반영완료)
  - 해당 값이 추가됨에 따라 방 정보 조회 API (#94)의 ResponseDto에도 category값이 추가되었다.
- 방 설정 정보 변경 API 구현
- default RestDocs Host가 `ddangkong.io`로 되어있는 것을 확인하고, 이번에 확정된 `ddangkong.kr`로 수정하였습니다.
- 방 정보 조회 API 구현 때 놓쳤던 Controller 메서드 ResponseStatus 애노테이션을 추가하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/2592b04c-c528-4ac3-8040-db3464d91913">
<img width="741" alt="스크린샷 2024-08-01 22 06 13" src="https://github.com/user-attachments/assets/e80c1612-a325-4bbe-8e56-9ca073681b0f">


## (Optional) Additional Description
- 커밋ID를 착각했습니다.. 수정해야할 것 같은데 도움주실 분 구합니다.