### PR TITLE
[REFACTOR] cd deploy job 시간제한 2분으로 조정

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -55,7 +55,7 @@ jobs:
 
   deploy:
     needs: build
-    timeout-minutes: 1
+    timeout-minutes: 2
     runs-on: [ self-hosted, linux, ARM64 ] # Self hosted runner 사용
     env:
       DOCKER_REPOSITORY_NAME: ddangkong/ddangkong-api-dev


### PR DESCRIPTION
## Issue Number
#116 

## As-Is
<!-- 문제 상황 정의 -->
<img width="759" alt="image" src="https://github.com/user-attachments/assets/9e4d22e5-ff22-4c7f-a01e-43dc19177489">
정상적인 상황에서 CD deploy job 타임아웃으로 인한 배포 실패가 발생하였다.

## To-Be
<!-- 변경 사항 -->
CD deploy job에 1분의 추가 여유시간을 두는 것으로 설정한다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
