### PR TITLE
[FIX] Backend CI runner 를 self-hosted로 변경

### DIFF
--- a/.github/workflows/be-ci-dev.yml
+++ b/.github/workflows/be-ci-dev.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     timeout-minutes: 4
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, linux, ARM64 ]
 
     defaults:
       run:


### PR DESCRIPTION
## Issue Number
#120 

## As-Is
<!-- 문제 상황 정의 -->
- 현재 CI를 ubuntu-lasted로 하면 루프에 걸리는 문제가 발생.
- 다른 팀들도 동일한 문제가 있는 것을 보아 Organization 문제인듯.
- 추후 문제 해결시 다시 ubuntu-lasted로 돌아갈 예정

## To-Be
<!-- 변경 사항 -->
- runs-on 을 ubuntu-lasted -> self-hosted-runner 로 변경


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="636" alt="image" src="https://github.com/user-attachments/assets/6566209c-d7f6-40d4-804d-0e791919f68f">


## (Optional) Additional Description
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/6c7dada7-4d97-4386-ab51-befa40443af0">
CI 파일 수정은 트리거로 잡히지 않아서 수동으로 돌려보았는데 정상동작합니다!
