### PR TITLE
[REFACTOR] 운영 환경 Rest Docs 생성 제외

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -37,7 +37,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew bootJar
+        run: ./gradlew bootJar -PcreateRestDocs
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/be-ci-dev.yml
+++ b/.github/workflows/be-ci-dev.yml
@@ -31,4 +31,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew test

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,15 +53,21 @@ tasks.named('jar') {
     enabled = false
 }
 
-tasks.named('test') {
+tasks.withType(Test).configureEach {
     useJUnitPlatform()
     reports.html.required = false
     reports.junitXml.required = false
+}
+
+tasks.register('restDocsTest', Test) {
     outputs.dir snippetsDir
+    filter {
+        includeTestsMatching 'ddangkong.documentation.*'
+    }
 }
 
 tasks.named('asciidoctor') {
-    dependsOn test
+    dependsOn restDocsTest
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     sources {
@@ -71,8 +77,10 @@ tasks.named('asciidoctor') {
 }
 
 tasks.named('bootJar') {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}") {
-        into 'static/docs'
+    if (project.hasProperty('createRestDocs')) {
+        dependsOn asciidoctor
+        from("${asciidoctor.outputDir}") {
+            into 'static/docs'
+        }
     }
 }


### PR DESCRIPTION
## Issue Number
close #118 

## As-Is
<!-- 문제 상황 정의 -->
api 문서 노출을 개발 환경으로 제한한다.

## To-Be
<!-- 변경 사항 -->
- REST Docs test 분리 (documentation 테스트만 실행)
- gradle 명령어에 `-PcreateRestDocs` 옵션을 사용해야 REST Docs 관련 task가 동작하도록 변경
- dev CI에서 test task 실행하도록 변경
- dev CD에서 bootJar task에  REST Docs 관련 task 포함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="611" alt="스크린샷 2024-08-04 오전 4 01 03" src="https://github.com/user-attachments/assets/1b375981-cefb-45ea-8b35-5e44b5a908eb">

옵션을 사용하지 않아 restDocsTest, asciidoctor task을 포함하지 않고 bootJar, test 후 빌드

<br/>

<img width="738" alt="스크린샷 2024-08-04 오전 4 01 52" src="https://github.com/user-attachments/assets/0ab2763b-57df-490a-b51d-1ad8cb5b4d06">

bootJar는 test task에 의존하지 않으므로 test 실행 x
옵션을 사용하여 restDocsTest, asciidoctor task을 포함해서 bootJar 실행

## (Optional) Additional Description
최적화를 위해서 test task에 documentation 테스트를 제외하도록 구성해볼까 했지만 로컬에서 확인할 때 불편할 것 같아서 반영하지 않았습니다
\+ CI 단계에서 documentation 테스트도 통과하는지 확인하기 위함

#### 제외할 경우

```gradle
// build.gradle

tasks.named('test') {
    useJUnitPlatform()
    filter {
        excludeTestsMatching 'ddangkong.documentation.*'
    }
}
```
<img width="738" alt="스크린샷 2024-08-04 오전 4 11 26" src="https://github.com/user-attachments/assets/38d4a89a-209c-48f1-99df-8d887e2290a9">

documentation 패키지 하위의 모든 테스트를 제외합니다
인텔리제이 상에서 모든 테스트를 돌려도 documentation을 제외해서 돌리기 때문에 adoc 스니펫이 생성되지 않습니다
로컬에서 adoc 스니펫을 생성해서 rest docs 결과를 보려면 `./gradlew asciidoctor` 명령어를 실행해야 하는 불편함이 있어서 test task는 그대로 유지합니다

#### 제외하지 않았을 경우
<img width="738" alt="스크린샷 2024-08-04 오전 4 10 51" src="https://github.com/user-attachments/assets/ad9d67eb-a1d7-464f-879f-c0cc83903949">