### PR TITLE
[FIX] 운영 환경 쿼리문 수정 

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -73,6 +73,7 @@ jobs:
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
           if [ -n "${CONTAINER_ID}" ]; then
           sudo docker rm -f ${CONTAINER_ID}
+          echo "Container ${CONTAINER_ID} is stopped and removed."
           else
           echo "No previous container found with name. Skipping removal."
           fi

--- a/backend/src/main/resources/sql/data-dev.sql
+++ b/backend/src/main/resources/sql/data-dev.sql
@@ -23,12 +23,12 @@ INSERT INTO room(total_round, current_round, time_limit, status, category)
 VALUES (5, 1, 30000, 'READY', 'EXAMPLE');
 
 
-INSERT INTO room_content(room_id, balance_content_id, round, created_at)
-VALUES (1, 1, 1, '2024-07-25 13:24:09'),
-       (1, 2, 2, '2024-07-25 13:24:09'),
-       (1, 3, 3, '2024-07-25 13:24:09'),
-       (1, 4, 4, '2024-07-25 13:24:09'),
-       (1, 5, 5, '2024-07-25 13:24:09');
+INSERT INTO room_content(room_id, balance_content_id, round, created_at, is_used)
+VALUES (1, 1, 1, '2024-07-25 13:24:09', false),
+       (1, 2, 2, '2024-07-25 13:24:09', false),
+       (1, 3, 3, '2024-07-25 13:24:09', false),
+       (1, 4, 4, '2024-07-25 13:24:09', false),
+       (1, 5, 5, '2024-07-25 13:24:09', false);
 
 
 INSERT INTO member(room_id, nickname, is_master)


### PR DESCRIPTION
## Issue Number
close #131 

## As-Is
<!-- 문제 상황 정의 -->
새롭게 추가된 RoomContent의 isUsed 필드가 운영 환경에 있는 data-dev.sql 파일에는 없어서 버그 발생

## To-Be
<!-- 변경 사항 -->
- data-dev.sql  에서 room_content 테이블에 is_used 필드 추가 
- CD 에서 컨테이너 삭제 확인 출력문 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="652" alt="image" src="https://github.com/user-attachments/assets/eb7cb95e-8922-4194-b9b3-57af6f902f13">


## (Optional) Additional Description
