### PR TITLE
[REFACTOR] storybook 배포 자동화

### DIFF
--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -40,7 +40,7 @@ jobs:
           publish_dir: ./frontend/storybook-static
           destination_dir: storybook
 
-      - name: comment storybook url
+      - name: add storybook url in PR description
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TOKEN }}
@@ -48,7 +48,7 @@ jobs:
             const pr = await github.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.issue.number
+                pull_number: context.payload.pull_request.number
             });
             const body = pr.data.body;
             const newBody = body + "\n\n" + "## 🌸 Storybook 배포 주소 \n\n"+ "> https://woowacourse-teams.github.io/2024-ddangkong/storybook/";

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -34,9 +34,8 @@ jobs:
         run: npm run build-storybook
 
       - name: upload storybook
-          uses: peaceiris/actions-gh-pages@v3
-          with:
-            github_token: ${{ secrets.TOKEN }}
-            publish_dir: ./frontend/storybook-static
-            destination_dir: storybook
-
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.TOKEN }}
+          publish_dir: ./frontend/storybook-static
+          destination_dir: storybook

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -45,14 +45,14 @@ jobs:
         with:
           github-token: ${{ secrets.TOKEN }}
           script: |
-            const pr = await github.pulls.get({
+            const pr = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number
+                pull_number: context.issue.number
             });
             const body = pr.data.body;
             const newBody = body + "\n\n" + "## 🌸 Storybook 배포 주소 \n\n"+ "> https://woowacourse-teams.github.io/2024-ddangkong/storybook/";
-            await github.pulls.update({
+            await github.rest.pulls.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: context.issue.number,

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -1,4 +1,4 @@
-name: storybook deploy
+name: FE CD storybook
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     concurrency:
@@ -39,3 +39,15 @@ jobs:
           github_token: ${{ secrets.TOKEN }}
           publish_dir: ./frontend/storybook-static
           destination_dir: storybook
+
+      - name: comment storybook url
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🎀 storybook 배포 주소 : https://woowacourse-teams.github.io/2024-ddangkong/storybook/'
+            })

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -12,7 +12,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -1,0 +1,42 @@
+name: storybook deploy
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "frontend/**"
+
+jobs:
+  build-and-deploy:
+    defaults:
+      run:
+        working-directory: frontend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: build storybook
+        run: npm run build-storybook
+
+      - name: upload storybook
+          uses: peaceiris/actions-gh-pages@v3
+          with:
+            github_token: ${{ secrets.TOKEN }}
+            publish_dir: ./frontend/storybook-static
+            destination_dir: storybook
+

--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -45,9 +45,16 @@ jobs:
         with:
           github-token: ${{ secrets.TOKEN }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🎀 storybook 배포 주소 : https://woowacourse-teams.github.io/2024-ddangkong/storybook/'
-            })
+            const pr = await github.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+            });
+            const body = pr.data.body;
+            const newBody = body + "\n\n" + "## 🌸 Storybook 배포 주소 \n\n"+ "> https://woowacourse-teams.github.io/2024-ddangkong/storybook/";
+            await github.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  body: newBody
+              });

--- a/.github/workflows/fe-ci-dev.yml
+++ b/.github/workflows/fe-ci-dev.yml
@@ -1,4 +1,4 @@
-name: Frontend CI
+name: FE CI for dev
 
 on:
   pull_request:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,7 +9,6 @@ lerna-debug.log*
 
 node_modules
 dist
-dist-ssr
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Issue Number
#125 

## As-Is
<!-- 문제 상황 정의 -->
- storybook을 배포하지 않아 매번 캡처해서 보내주거나 리뷰어가 로컬에서 돌려봐야함

## To-Be
<!-- 변경 사항 -->
- github actions를 활용해 storybook 배포를 자동화하여 팀원이 만든 컴포넌트 확인
- github pages 활용하여 storybook 배포

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
- organization 권한 없을으로 chromatic 불가
- codebuild로 서비스랑 함께 배포하려고 했으나 디렉토리 분리가 안되서 실패 (이건 내가 못하는 걸수도) -> 성공
- [github script](https://github.com/actions/github-script?tab=readme-ov-file) 참고해서 스크립트 수정 [(octokit.js)](https://octokit.github.io/rest.js/v20)

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/