### PR TITLE
[FEAT] HTTPS, DNS 설정

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -28,7 +28,7 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV_YML }}" > ./src/main/resources/application-dev.yml
 
       - name: Setting SSL/TLS Key
-        run: echo "${{ secrets.SSL_KEY }}" > ./src/main/resources/ssl/keystore.p12
+        run: echo "${{ secrets.SSL_KEY_BASE64 }}" | base64 -d > ./src/main/resources/ssl/keystore.p12
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -77,19 +77,20 @@ jobs:
         run: |
           CONTAINER_ID=$(sudo docker ps -aqf name=$CONTAINER_NAME)
           if [ -n "${CONTAINER_ID}" ]; then
-          sudo docker rm -f ${CONTAINER_ID}
-          echo "Container ${CONTAINER_ID} is stopped and removed."
+            sudo docker rm -f ${CONTAINER_ID}
+            echo "Container ${CONTAINER_ID} is stopped and removed."
           else
-          echo "No previous container found with name. Skipping removal."
+            echo "No previous container found with name. Skipping removal."
           fi
 
       - name: Remove previous Docker image
         run: |    
           IMAGE_ID=$(sudo docker images --filter=reference=ddangkong/ddangkong-api-dev --format "{{.ID}}")
           if [ -n "${IMAGE_ID}" ]; then
-          sudo docker rmi ${IMAGE_ID}
+            sudo docker rmi ${IMAGE_ID}
+            echo "Image ${IMAGE_ID} is removed."
           else
-          echo "No previous image found with repository name. Skipping removal."
+            echo "No previous image found with repository name. Skipping removal."
           fi
 
       - name: Pull docker image

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -28,7 +28,9 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV_YML }}" > ./src/main/resources/application-dev.yml
 
       - name: Setting SSL/TLS Key
-        run: echo "${{ secrets.SSL_KEY_BASE64 }}" | base64 -d > ./src/main/resources/ssl/keystore.p12
+        run: |
+          mkdir -p ./src/main/resources/ssl
+          echo "${{ secrets.SSL_KEY_BASE64 }}" | base64 -d > ./src/main/resources/ssl/keystore.p12
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Setting SSL/TLS Key
         run: |
           mkdir -p ./src/main/resources/ssl
-          echo "${{ secrets.SSL_PUBLIC_KEY }}" > ./src/main/resources/ssl/publicKey.pem
-          echo "${{ secrets.SSL_PRIVATE_KEY }}" > ./src/main/resources/ssl/privateKey.pem
+          echo "${{ secrets.SSL_PUBLIC_KEY }}" > ./src/main/resources/ssl/keystore.p12
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           echo "${{ secrets.APPLICATION_DEV_YML }}" > ./src/main/resources/application-dev.yml
 
+      - name: Setting SSL/TLS Key
+        run: echo "${{ secrets.SSL_KEY }}" > ./src/main/resources/ssl/keystore.p12
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setting SSL/TLS Key
         run: |
           mkdir -p ./src/main/resources/ssl
-          echo "${{ secrets.SSL_PUBLIC_KEY }}" > ./src/main/resources/ssl/keystore.p12
+          echo "${{ secrets.SSL_KEY_BASE64 }}" | base64 -d > ./src/main/resources/ssl/keystore.p12
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -95,5 +95,5 @@ jobs:
 
       - name: Run new Docker container
         run: |
-          sudo nohup docker run -p 80:8080 --name $CONTAINER_NAME \
+          sudo nohup docker run -p 443:8080 --name $CONTAINER_NAME \
           $DOCKER_REPOSITORY_NAME:latest > ~/dev-nohup.out 2>&1 &

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Setting SSL/TLS Key
         run: |
           mkdir -p ./src/main/resources/ssl
-          echo "${{ secrets.SSL_KEY_BASE64 }}" | base64 -d > ./src/main/resources/ssl/keystore.p12
+          echo "${{ secrets.SSL_PUBLIC_KEY }}" > ./src/main/resources/ssl/publicKey.pem
+          echo "${{ secrets.SSL_PRIVATE_KEY }}" > ./src/main/resources/ssl/privateKey.pem
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -67,6 +68,10 @@ jobs:
       CONTAINER_NAME: ddangkong-api-dev
 
     steps:
+      - name: Setting application-dev.yml
+        run: |
+          echo "${{ secrets.APPLICATION_DEV_YML }}" > ~/application-dev.yml
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -67,10 +67,6 @@ jobs:
       CONTAINER_NAME: ddangkong-api-dev
 
     steps:
-      - name: Setting application-dev.yml
-        run: |
-          echo "${{ secrets.APPLICATION_DEV_YML }}" > ~/application-dev.yml
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/backend/src/main/java/ddangkong/config/CorsConfig.java
+++ b/backend/src/main/java/ddangkong/config/CorsConfig.java
@@ -1,6 +1,5 @@
 package ddangkong.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,11 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    private final String corsOrigin;
-
-    public CorsConfig(@Value("${cors.origin}") String corsOrigin) {
-        this.corsOrigin = corsOrigin;
-    }
+    private final String corsOrigin = "*";
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/backend/src/main/java/ddangkong/config/CorsConfig.java
+++ b/backend/src/main/java/ddangkong/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package ddangkong.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,7 +9,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    private final String corsOrigin = "*";
+    private final String corsOrigin;
+
+    public CorsConfig(@Value("${cors.origin}") String corsOrigin) {
+        this.corsOrigin = corsOrigin;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
## Issue Number
#145 

## As-Is
<!-- 문제 상황 정의 -->
### HTTPS 설정

- 현재 프론트엔드에서 **`CloudFront`** 로 배포했기 때문에 HTTPS로 동작하고 있었다.
하지만 백엔드의 API 서버는 HTTP 프로토콜로 동작하고 제공하고 있었기 때문에
HTTPS인 프론트는 API 서버를 사용할 수 없었다.
때문에 HTTP로 제공되던 API를 HTTPS 로 변경하는 작업을 하고자 하였다.

### DNS 설정

- IP 주소를 외워서 사용하는 것보다, 이해하기 쉬운 영문 주소를 활용하는 것이 훨씬 편리하다.
- EC2의 탄력적IP를 사용할 것이 아니기 때문에 IP 주소가 변경될 가능성이 있는데,
그에 따라 클라이언트에서 요청을 보내는 API주소를 변경하여 재배포하지 않으면 API 요청이 이루어지지 않는다. 이때 클라이언트를 재배포하는 것보다 가비아에서 A레코드에 작성된 API서버 주소만 변경해주는 것이 더 좋은 방안이라고 생각했다.

## To-Be
<!-- 변경 사항 -->
https://www.notion.so/ghenmaru/HTTPS-DNS-with-certbot-d76459524ee646e28ebf0e0772957710

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1123" alt="스크린샷 2024-08-06 22 20 25" src="https://github.com/user-attachments/assets/75886181-da64-441d-84ac-b6c0d4fc3fb4">


## (Optional) Additional Description
