### PR TITLE
[FIX] API 문서 오류 수정

### DIFF
--- a/backend/src/docs/asciidoc/balanceVote.adoc
+++ b/backend/src/docs/asciidoc/balanceVote.adoc
@@ -20,6 +20,8 @@ response fields
 
 include::{snippets}/balanceVote/findRoundResult/response-fields.adoc[]
 
+---
+
 === 투표 생성
 
 ==== curl
@@ -43,6 +45,8 @@ include::{snippets}/balanceVote/createBalanceVote/http-response.adoc[]
 response fields
 
 include::{snippets}/balanceVote/createBalanceVote/response-fields.adoc[]
+
+---
 
 === 투표 종료 여부
 

--- a/backend/src/docs/asciidoc/exception.adoc
+++ b/backend/src/docs/asciidoc/exception.adoc
@@ -14,6 +14,8 @@ response fields
 
 include::{snippets}/exception/business-error/response-fields.adoc[]
 
+---
+
 === field error
 
 ==== example request
@@ -29,6 +31,8 @@ include::{snippets}/exception/field-error/http-response.adoc[]
 response fields
 
 include::{snippets}/exception/field-error/response-fields.adoc[]
+
+---
 
 === url parameter error
 

--- a/backend/src/docs/asciidoc/room.adoc
+++ b/backend/src/docs/asciidoc/room.adoc
@@ -22,6 +22,8 @@ response fields
 
 include::{snippets}/room/create/response-fields.adoc[]
 
+---
+
 === 방 참여
 
 ==== curl
@@ -46,6 +48,8 @@ response fields
 
 include::{snippets}/room/join/response-fields.adoc[]
 
+---
+
 === 방 설정 변경
 
 ==== curl
@@ -63,6 +67,8 @@ include::{snippets}/room/setting/request-fields.adoc[]
 ==== response
 
 include::{snippets}/room/setting/http-response.adoc[]
+
+---
 
 === 방 정보 조회
 
@@ -84,6 +90,8 @@ response fields
 
 include::{snippets}/room/info/response-fields.adoc[]
 
+---
+
 === 게임 시작
 
 ==== curl
@@ -100,6 +108,8 @@ include::{snippets}/room/start/path-parameters.adoc[]
 
 include::{snippets}/room/start/http-response.adoc[]
 
+---
+
 === 다음 라운드로 이동
 
 ==== curl
@@ -115,6 +125,8 @@ include::{snippets}/room/nextRound/path-parameters.adoc[]
 ==== response
 
 include::{snippets}/room/nextRound/http-response.adoc[]
+
+---
 
 === 라운드 종료 여부
 
@@ -137,6 +149,8 @@ include::{snippets}/room/roundFinished/http-response.adoc[]
 response fields
 
 include::{snippets}/room/roundFinished/response-fields.adoc[]
+
+---
 
 === 방 초기화
 

--- a/backend/src/docs/asciidoc/room.adoc
+++ b/backend/src/docs/asciidoc/room.adoc
@@ -58,6 +58,8 @@ include::{snippets}/room/setting/http-request.adoc[]
 
 include::{snippets}/room/setting/path-parameters.adoc[]
 
+include::{snippets}/room/setting/request-fields.adoc[]
+
 ==== response
 
 include::{snippets}/room/setting/http-response.adoc[]

--- a/backend/src/test/java/ddangkong/documentation/BaseDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/BaseDocumentationTest.java
@@ -34,7 +34,7 @@ public abstract class BaseDocumentationTest {
                         .withRequestDefaults(
                                 modifyUris()
                                         .scheme("https")
-                                        .host("ddangkong.kr")
+                                        .host("api.dev.ddangkong.kr")
                                         .removePort(),
                                 prettyPrint(),
                                 modifyHeaders().remove(HttpHeaders.CONTENT_LENGTH)


### PR DESCRIPTION
## Issue Number
#161 

## As-Is
<!-- 문제 상황 정의 -->
- REST Docs 방 설정 변경 Request 문서에 request-fields 내용이 빠져있었다.
- Domain 주소가 api.dev.ddangkong.kr로 변경되면서 기존 문서에 작성되어 있던 도메인 주소를 수정하게 되었다.

## To-Be
<!-- 변경 사항 -->
- 방 설정 변경 Request 문서에 request-fields 내용 추가
- 문서 상의 Domain 주소를 api.dev.ddangkong.kr로 변경하였다.
- API 별로 구분 라인을 추가해서 가독성을 높였다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
