### PR TITLE
[FEAT] 문서 변경 알림 Notificator 스크립트 설정

### DIFF
--- a/.github/workflows/be-document-notification-dev.yml
+++ b/.github/workflows/be-document-notification-dev.yml
@@ -3,7 +3,7 @@ name: BE Document Change Discord Notification for Dev
 on:
   workflow_dispatch:
 
-  pull_request:
+  push:
     branches: [ "develop" ]
     paths:
       - backend/src/docs/asciidoc/**

--- a/.github/workflows/be-document-notification-dev.yml
+++ b/.github/workflows/be-document-notification-dev.yml
@@ -20,7 +20,11 @@ jobs:
           webhook-url: ${{ secrets.ASCIIDOC_NOTIFICATION_WEBHOOK_URL }}
           username: Document Notificator
           content: |
-            📃 Dev 서버 API 문서에 변경이 발생했습니다!
+            ================================================
+            
+            ##  📃 Dev 서버 API 문서에 변경이 발생했습니다!
             
             ⬆️ [PR 바로가기](${{ github.event.pull_request.html_url }})
             ⬆️ [Docs 바로가기](https://api.dev.ddangkong.kr/docs/index.html)
+            
+            ================================================

--- a/.github/workflows/be-document-notification-dev.yml
+++ b/.github/workflows/be-document-notification-dev.yml
@@ -19,11 +19,8 @@ jobs:
         with:
           webhook-url: ${{ secrets.ASCIIDOC_NOTIFICATION_WEBHOOK_URL }}
           username: Document Notificator
-          content: | 
+          content: |
             📃 Dev 서버 API 문서에 변경이 발생했습니다!
             
-            ⬆️[PR 바로가기](${{ github.event.pull_request.html_url }})
-            ⬆️[Docs 바로가기](api.dev.ddangkong.kr)
-
-
-
+            ⬆️ [PR 바로가기](${{ github.event.pull_request.html_url }})
+            ⬆️ [Docs 바로가기](https://api.dev.ddangkong.kr/docs/index.html)

--- a/.github/workflows/be-document-notification-dev.yml
+++ b/.github/workflows/be-document-notification-dev.yml
@@ -1,0 +1,29 @@
+name: BE Document Change Discord Notification for Dev
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: [ "develop" ]
+    paths:
+      - backend/src/docs/asciidoc/**
+      - backend/src/test/java/ddangkong/documentation/**
+
+jobs:
+  build:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.ASCIIDOC_NOTIFICATION_WEBHOOK_URL }}
+          username: Document Notificator
+          content: | 
+            📃 Dev 서버 API 문서에 변경이 발생했습니다!
+            
+            ⬆️[PR 바로가기](${{ github.event.pull_request.html_url }})
+            ⬆️[Docs 바로가기](api.dev.ddangkong.kr)
+
+
+

--- a/.github/workflows/be-document-notification-dev.yml
+++ b/.github/workflows/be-document-notification-dev.yml
@@ -10,7 +10,7 @@ on:
       - backend/src/test/java/ddangkong/documentation/**
 
 jobs:
-  build:
+  notification:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Issue Number
#163 

## As-Is
<!-- 문제 상황 정의 -->

최근 프론트에서 API 문서가 변경된 것을 인지하지 못하고 이전 버전의 API를 호출하느라 오랜 시간을 허비하는 일이 발생했다.

이 일을 통해 REST Docs 변경 시, 백엔드가 클라이언트에게 제대로 전달해주지 않는다면
클라이언트 측에서 즉각적으로 변경을 인지하기 힘들어 위와 같은 문제가 반복될 것이라는 생각이 들었다.

때문에 API 문서 변경 알림 과정을 자동화하여 문제를 해보고자 한다.

## To-Be
<!-- 변경 사항 -->

현재 사용하는 협업 툴인 Discord를 통해 REST Docs 문서 관련 코드 변경 시, 알림을 전달한다.
[Ddangkong Notion](https://www.notion.so/ghenmaru/v1-0-0b1d537d8ea641a697ed24ad742a07f7?pvs=4)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="440" alt="image" src="https://github.com/user-attachments/assets/fd4309fc-cdde-45ba-ab8e-d437debfc9af">


## (Optional) Additional Description
