### PR TITLE
[REFACTOR] Pretandard 폰트 설정

### DIFF
--- a/.github/workflows/fe-cd-storybook.yml
+++ b/.github/workflows/fe-cd-storybook.yml
@@ -39,6 +39,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: generate environment variables
+        run: |
+          echo "API_BASE_URL=$API_BASE_URL" >> .env
+        env:
+          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+
       - name: build storybook
         run: npm run build-storybook
 

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -5,10 +5,14 @@ import { MemoryRouter } from 'react-router-dom';
 import { Global, ThemeProvider } from '@emotion/react';
 import GlobalStyle from '../src/styles/GlobalStyle';
 import { Theme } from '../src/styles/Theme';
-import { initialize, mswDecorator, mswLoader } from 'msw-storybook-addon';
+import { initialize, mswDecorator } from 'msw-storybook-addon';
 import { handlers } from '../src/mocks/handlers';
 
-initialize();
+initialize({
+  serviceWorker: {
+    url: './mockServiceWorker.js',
+  },
+});
 
 const queryClient = new QueryClient();
 
@@ -24,7 +28,6 @@ const preview: Preview = {
       },
     },
   },
-  loaders: [mswLoader],
   decorators: [
     (Story) => (
       <QueryClientProvider client={queryClient}>

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { Global, ThemeProvider } from '@emotion/react';
 import GlobalStyle from '../src/styles/GlobalStyle';
 import { Theme } from '../src/styles/Theme';
-import { initialize, mswDecorator } from 'msw-storybook-addon';
+import { initialize, mswLoader } from 'msw-storybook-addon';
 import { handlers } from '../src/mocks/handlers';
 
 initialize({
@@ -28,6 +28,7 @@ const preview: Preview = {
       },
     },
   },
+  loaders: [mswLoader],
   decorators: [
     (Story) => (
       <QueryClientProvider client={queryClient}>
@@ -39,7 +40,6 @@ const preview: Preview = {
         </ThemeProvider>
       </QueryClientProvider>
     ),
-    mswDecorator,
   ],
 };
 

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -8,7 +8,11 @@ import { Theme } from '../src/styles/Theme';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 import { handlers } from '../src/mocks/handlers';
 
-initialize();
+initialize({
+  serviceWorker: {
+    url: './mockServiceWorker.js',
+  },
+});
 
 const queryClient = new QueryClient();
 

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -5,14 +5,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { Global, ThemeProvider } from '@emotion/react';
 import GlobalStyle from '../src/styles/GlobalStyle';
 import { Theme } from '../src/styles/Theme';
-import { initialize, mswDecorator } from 'msw-storybook-addon';
+import { initialize, mswDecorator, mswLoader } from 'msw-storybook-addon';
 import { handlers } from '../src/mocks/handlers';
 
-initialize({
-  serviceWorker: {
-    url: './mockServiceWorker.js',
-  },
-});
+initialize();
 
 const queryClient = new QueryClient();
 
@@ -28,6 +24,7 @@ const preview: Preview = {
       },
     },
   },
+  loaders: [mswLoader],
   decorators: [
     (Story) => (
       <QueryClientProvider client={queryClient}>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ddangkong</title>
+  <link rel="stylesheet" as="style" crossorigin
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable.css" />
 </head>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-3BFVVPQT0Z"></script>
 <script>

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -156,22 +156,7 @@ const GlobalStyle = css`
 
   * {
     box-sizing: border-box;
-    font-family:
-      'Pretendard Variable',
-      Pretendard,
-      -apple-system,
-      BlinkMacSystemFont,
-      system-ui,
-      Roboto,
-      'Helvetica Neue',
-      'Segoe UI',
-      'Apple SD Gothic Neo',
-      'Noto Sans KR',
-      'Malgun Gothic',
-      'Apple Color Emoji',
-      'Segoe UI Emoji',
-      'Segoe UI Symbol',
-      sans-serif;
+    font-family: 'Pretendard Variable', Pretendard, sans-serif;
   }
 `;
 

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -157,6 +157,22 @@ const GlobalStyle = css`
 
   * {
     box-sizing: border-box;
+    font-family:
+      'Pretendard Variable',
+      Pretendard,
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      Roboto,
+      'Helvetica Neue',
+      'Segoe UI',
+      'Apple SD Gothic Neo',
+      'Noto Sans KR',
+      'Malgun Gothic',
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol',
+      sans-serif;
   }
 `;
 

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -85,7 +85,6 @@ const reset = css`
     margin: 0;
     padding: 0;
     border: 0;
-    font: inherit;
 
     font-size: 100%;
     vertical-align: baseline;


### PR DESCRIPTION
## Issue Number
#149 

## As-Is
<!-- 문제 상황 정의 -->
- 브라우저마다 폰트가 다르게 적용되고, 폰트마다 기본 크기가 달라 UI가 깨지는 문제 발생

## To-Be
<!-- 변경 사항 -->
구글 웹폰트 Pretandard 적용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

크롬은 적용된 게 크게 차이안나서, 사파리 브라우저로 확인

<img width="300" alt="image" src="https://github.com/user-attachments/assets/08c03eaa-4471-4e17-8805-a2347c791eb7">

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a8ad4f5d-aa1b-4264-84e9-644892531aff">


## (Optional) Additional Description
- 추후 다른 폰트로 바꿀 수도 있음
- preload 적용하면 빠른 것 까진 확인했는데 폰트가 제대로 적용되지 않아 일단 패스

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/