### PR TITLE
[FIX] 라운드 결과 조회 시, 전원이 투표 했음에도 결과가 조회되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
@@ -112,7 +112,6 @@ public class RoomBalanceVoteService {
                 .findByMemberRoomAndBalanceOption(room, balanceOptions.getFistOption());
         List<RoomBalanceVote> secondOptionVotes = roomBalanceVoteRepository
                 .findByMemberRoomAndBalanceOption(room, balanceOptions.getSecondOption());
-
         return ContentRoomBalanceVoteResponse.create(balanceOptions, firstOptionVotes, secondOptionVotes);
     }
 

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
@@ -61,7 +61,7 @@ public class RoomBalanceVoteService {
     }
 
     private void validateRoundFinished(Room room, BalanceContent balanceContent) {
-        if (isRoundFinished(room, balanceContent)) {
+        if (isVoteFinished(room, balanceContent)) {
             throw new BadRequestException("이미 종료된 라운드에는 투표할 수 없습니다.");
         }
     }
@@ -97,7 +97,7 @@ public class RoomBalanceVoteService {
     public RoomBalanceVoteResultResponse getAllVoteResult(Long roomId, Long balanceContentId) {
         Room room = roomRepository.getById(roomId);
         BalanceContent balanceContent = balanceContentRepository.getById(balanceContentId);
-        if (isRoundFinished(room, balanceContent)) {
+        if (isVoteFinished(room, balanceContent)) {
             BalanceOptions balanceOptions = balanceOptionRepository.getBalanceOptionsByBalanceContent(balanceContent);
             // todo 기권 추가
             ContentRoomBalanceVoteResponse group = getContentRoomBalanceVoteResponse(room, balanceOptions);
@@ -126,10 +126,10 @@ public class RoomBalanceVoteService {
     public VoteFinishedResponse getAllVoteFinished(Long roomId, Long contentId) {
         Room room = roomRepository.getById(roomId);
         BalanceContent balanceContent = balanceContentRepository.getById(contentId);
-        return VoteFinishedResponse.roundFinished(isRoundFinished(room, balanceContent));
+        return VoteFinishedResponse.voteFinished(isVoteFinished(room, balanceContent));
     }
 
-    private boolean isRoundFinished(Room room, BalanceContent balanceContent) {
+    private boolean isVoteFinished(Room room, BalanceContent balanceContent) {
         return isTimeOver(room, balanceContent) || isAllVoteFinished(room, balanceContent);
     }
 

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
@@ -127,13 +127,14 @@ public class RoomBalanceVoteService {
     public VoteFinishedResponse getAllVoteFinished(Long roomId, Long contentId) {
         Room room = roomRepository.getById(roomId);
         BalanceContent balanceContent = balanceContentRepository.getById(contentId);
-        if (isRoundFinished(room, balanceContent)) {
-            return VoteFinishedResponse.roundFinished();
-        }
-        return VoteFinishedResponse.allVoteFinished(isAllVoteFinished(room, balanceContent));
+        return VoteFinishedResponse.roundFinished(isRoundFinished(room, balanceContent));
     }
 
     private boolean isRoundFinished(Room room, BalanceContent balanceContent) {
+        return isTimeOver(room, balanceContent) || isAllVoteFinished(room, balanceContent);
+    }
+
+    private boolean isTimeOver(Room room, BalanceContent balanceContent) {
         RoomContent roomContent = roomContentRepository.getByRoomAndBalanceContent(room, balanceContent);
         LocalDateTime now = LocalDateTime.now(clock);
         return roomContent.isRoundOver(now, room.getCurrentRound());

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/dto/VoteFinishedResponse.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/dto/VoteFinishedResponse.java
@@ -4,7 +4,7 @@ public record VoteFinishedResponse(
         boolean isFinished
 ) {
 
-    public static VoteFinishedResponse roundFinished(boolean isAllVoteFinished) {
+    public static VoteFinishedResponse voteFinished(boolean isAllVoteFinished) {
         return new VoteFinishedResponse(isAllVoteFinished);
     }
 }

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/dto/VoteFinishedResponse.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/dto/VoteFinishedResponse.java
@@ -4,11 +4,7 @@ public record VoteFinishedResponse(
         boolean isFinished
 ) {
 
-    public static VoteFinishedResponse roundFinished() {
-        return new VoteFinishedResponse(true);
-    }
-
-    public static VoteFinishedResponse allVoteFinished(boolean isAllVoteFinished) {
+    public static VoteFinishedResponse roundFinished(boolean isAllVoteFinished) {
         return new VoteFinishedResponse(isAllVoteFinished);
     }
 }

--- a/backend/src/main/java/ddangkong/util/PercentageCalculator.java
+++ b/backend/src/main/java/ddangkong/util/PercentageCalculator.java
@@ -8,13 +8,18 @@ import lombok.NoArgsConstructor;
 public class PercentageCalculator {
 
     private static final double SECOND_DECIMAL_PLACE_ROUNDING_FACTOR = 100.0;
+    private static final int DEFAULT_PERCENTAGE = 50;
 
     public static int calculatePercent(long count, long totalCount) {
         if (count < 0) {
             throw new InternalServerException("count는 0이상이어야 합니다. count: %d".formatted(count));
         }
-        if (totalCount < 1) {
-            throw new InternalServerException("totalCount는 1이상이어야 합니다. totalCount: %d".formatted(totalCount));
+        if (totalCount < 0) {
+            throw new InternalServerException("totalCount는 0이상이어야 합니다. totalCount: %d".formatted(totalCount));
+        }
+
+        if (totalCount == 0) {
+            return DEFAULT_PERCENTAGE;
         }
         return (int) Math.round(count * SECOND_DECIMAL_PLACE_ROUNDING_FACTOR / totalCount);
     }

--- a/backend/src/test/java/ddangkong/util/PercentageCalculatorTest.java
+++ b/backend/src/test/java/ddangkong/util/PercentageCalculatorTest.java
@@ -22,15 +22,28 @@ class PercentageCalculatorTest {
     }
 
     @Test
-    void totalCount가_1보다_작으면_예외가_발생한다() {
+    void totalCount가_0인_경우_기본값을_반환한다() {
+        // given
+        long count = 0L;
+        long totalCount = 0L;
+
+        // when
+        int percent = PercentageCalculator.calculatePercent(count, totalCount);
+
+        // then
+        assertThat(percent).isEqualTo(50);
+    }
+
+    @Test
+    void totalCount가_0보다_작으면_예외가_발생한다() {
         // given
         long count = 3L;
-        long totalCount = 0L;
+        long totalCount = -1L;
 
         // when & then
         assertThatThrownBy(() -> PercentageCalculator.calculatePercent(count, totalCount))
                 .isExactlyInstanceOf(InternalServerException.class)
-                .hasMessageContaining("totalCount는 1이상이어야 합니다. totalCount: 0");
+                .hasMessageContaining("totalCount는 0이상이어야 합니다. totalCount: -1");
     }
 
     @Test
@@ -44,4 +57,5 @@ class PercentageCalculatorTest {
                 .isExactlyInstanceOf(InternalServerException.class)
                 .hasMessageContaining("count는 0이상이어야 합니다. count: -1");
     }
+
 }


### PR DESCRIPTION
## Issue Number
close #189

## As-Is
<!-- 문제 상황 정의 -->
- 라운드 종료 검증 로직이 시간이 끝났는지만을 확인함(전원 투표는 확인하지 않았음)
- PercentageCalculator 에서 totalCount가 0인 경우 에러가 발생한다.
  - total_balance_vote 가 비어있어서 예외가 발생했었음


## To-Be
<!-- 변경 사항 -->
- 라운드 종료 확인 메서드에 전원 투표 검증 추가
- PercentageCalculator의 totalCount 가 0인 경우 50을 리턴하도록 변경

## Check List
- [X] 테스트가 전부 통과되었나요?
- [X] 모든 commit이 push 되었나요?
- [X] merge할 branch를 확인했나요?
- [X] Assignee를 지정했나요?
- [X] Label을 지정했나요?

## Test Screenshot
<img width="814" alt="image" src="https://github.com/user-attachments/assets/0536aeca-9c0e-4ff5-b309-8172abe971eb">


## (Optional) Additional Description
