### PR TITLE
[FEAT] 방 접속 시 API Path에 사용하는 RoomID를 UUID로 변경

### DIFF
--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -50,9 +50,9 @@ public class RoomController {
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/balances/rooms/{roomId}/members")
-    public RoomJoinResponse joinRoom(@PathVariable @Positive Long roomId, @Valid @RequestBody RoomJoinRequest request) {
-        return roomService.joinRoom(request.nickname(), roomId);
+    @PostMapping("/balances/rooms/{uuid}/members")
+    public RoomJoinResponse joinRoom(@PathVariable String uuid, @Valid @RequestBody RoomJoinRequest request) {
+        return roomService.joinRoom(request.nickname(), uuid);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/backend/src/main/java/ddangkong/domain/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/room/Room.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,9 @@ public class Room {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
+    private String uuid;
+
     @Column(nullable = false)
     private int totalRound;
 
@@ -48,7 +52,8 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private Category category;
 
-    public Room(int totalRound, int currentRound, int timeLimit, RoomStatus status, Category category) {
+    public Room(String uuid, int totalRound, int currentRound, int timeLimit, RoomStatus status, Category category) {
+        this.uuid = uuid;
         this.totalRound = totalRound;
         this.currentRound = currentRound;
         this.timeLimit = timeLimit;
@@ -57,7 +62,11 @@ public class Room {
     }
 
     public static Room createNewRoom() {
-        return new Room(DEFAULT_TOTAL_ROUND, START_ROUND, MAX_TIME_LIMIT_MSEC, RoomStatus.READY, Category.EXAMPLE);
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        
+        return new Room(uuid, DEFAULT_TOTAL_ROUND, START_ROUND, MAX_TIME_LIMIT_MSEC,
+                RoomStatus.READY,
+                Category.EXAMPLE);
     }
 
     public void updateTimeLimit(int timeLimit) {

--- a/backend/src/main/java/ddangkong/domain/room/Room.java
+++ b/backend/src/main/java/ddangkong/domain/room/Room.java
@@ -63,9 +63,8 @@ public class Room {
 
     public static Room createNewRoom() {
         String uuid = UUID.randomUUID().toString().replace("-", "");
-        
-        return new Room(uuid, DEFAULT_TOTAL_ROUND, START_ROUND, MAX_TIME_LIMIT_MSEC,
-                RoomStatus.READY,
+
+        return new Room(uuid, DEFAULT_TOTAL_ROUND, START_ROUND, MAX_TIME_LIMIT_MSEC, RoomStatus.READY,
                 Category.EXAMPLE);
     }
 

--- a/backend/src/main/java/ddangkong/domain/room/RoomRepository.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomRepository.java
@@ -18,6 +18,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
-    @Query("SELECT r FROM Room r WHERE r.id = :id")
-    Optional<Room> findByIdWithLock(Long id);
+    @Query("SELECT r FROM Room r WHERE r.uuid = :uuid")
+    Optional<Room> findByUuidWithLock(String uuid);
 }

--- a/backend/src/main/java/ddangkong/service/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/room/RoomService.java
@@ -65,8 +65,8 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomJoinResponse joinRoom(String nickname, Long roomId) {
-        Room room = roomRepository.findByIdWithLock(roomId)
+    public RoomJoinResponse joinRoom(String nickname, String roomUuid) {
+        Room room = roomRepository.findByUuidWithLock(roomUuid)
                 .orElseThrow(() -> new BadRequestException("해당 방이 존재하지 않습니다."));
 
         long memberCountInRoom = memberRepository.countByRoom(room);

--- a/backend/src/main/java/ddangkong/service/room/RoomService.java
+++ b/backend/src/main/java/ddangkong/service/room/RoomService.java
@@ -61,7 +61,7 @@ public class RoomService {
     public RoomJoinResponse createRoom(String nickname) {
         Room room = roomRepository.save(Room.createNewRoom());
         Member member = memberRepository.save(Member.createMaster(nickname, room));
-        return new RoomJoinResponse(room.getId(), new MemberResponse(member));
+        return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 
     @Transactional
@@ -75,7 +75,7 @@ public class RoomService {
         }
 
         Member member = memberRepository.save(Member.createCommon(nickname, room));
-        return new RoomJoinResponse(room.getId(), new MemberResponse(member));
+        return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 
     @Transactional

--- a/backend/src/main/java/ddangkong/service/room/dto/RoomJoinResponse.java
+++ b/backend/src/main/java/ddangkong/service/room/dto/RoomJoinResponse.java
@@ -4,6 +4,7 @@ import ddangkong.service.room.member.dto.MemberResponse;
 
 public record RoomJoinResponse(
         Long roomId,
+        String roomUuid,
         MemberResponse member
 ) {
 }

--- a/backend/src/main/resources/sql/data-dev.sql
+++ b/backend/src/main/resources/sql/data-dev.sql
@@ -19,8 +19,8 @@ VALUES ('민초', 1),
        ('어떻게 죽을 지 알기', 5);
 
 
-INSERT INTO room(total_round, current_round, time_limit, status, category)
-VALUES (5, 1, 30000, 'PROGRESS', 'EXAMPLE');
+INSERT INTO room(uuid, total_round, current_round, time_limit, status, category)
+VALUES ('uuid1', 5, 1, 30000, 'PROGRESS', 'EXAMPLE');
 
 
 INSERT INTO room_content(room_id, balance_content_id, round, round_ended_at, is_used)

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -227,7 +227,8 @@ class RoomControllerTest extends BaseControllerTest {
         @BeforeEach
         void setUp() {
             BalanceContent content = balanceContentRepository.save(new BalanceContent(Category.EXAMPLE, "A vs B"));
-            room = roomRepository.save(new Room(3, 3, 30, RoomStatus.FINISH, Category.EXAMPLE));
+            room = roomRepository.save(new Room("roomResetSetUpUUID", 3, 3, 30,
+                    RoomStatus.FINISH, Category.EXAMPLE));
             roomContentRepository.save(new RoomContent(room, content, 1, null, false));
             roomContentRepository.save(new RoomContent(room, content, 2, null, false));
             roomContentRepository.save(new RoomContent(room, content, 3, null, false));

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -113,15 +113,16 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방에_참가할_수_있다() {
             // given
+            Room room = roomRepository.save(Room.createNewRoom());
             String nickname = "참가자";
             Map<String, Object> body = Map.of("nickname", nickname);
 
             // when & then
             RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
-                    .pathParam("roomId", 1L)
+                    .pathParam("uuid", room.getUuid())
                     .body(body)
-                    .when().post("/api/balances/rooms/{roomId}/members")
+                    .when().post("/api/balances/rooms/{uuid}/members")
                     .then().log().all()
                     .statusCode(201)
                     .extract().as(RoomJoinResponse.class);
@@ -130,15 +131,16 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방에_참가한_멤버는_방장이_아니다() {
             // given
+            Room room = roomRepository.save(Room.createNewRoom());
             String nickname = "참가자";
             Map<String, Object> body = Map.of("nickname", nickname);
 
             // when & then
             RoomJoinResponse actual = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
-                    .pathParam("roomId", 1L)
+                    .pathParam("uuid", room.getUuid())
                     .body(body)
-                    .when().post("/api/balances/rooms/{roomId}/members")
+                    .when().post("/api/balances/rooms/{uuid}/members")
                     .then().log().all()
                     .statusCode(201)
                     .extract().as(RoomJoinResponse.class);

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -166,7 +166,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             // given
             RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
                     new MemberResponse(2L, "타콩", false));
-            when(roomService.joinRoom(anyString(), anyLong())).thenReturn(response);
+            when(roomService.joinRoom(anyString(), anyString())).thenReturn(response);
 
             RoomJoinRequest request = new RoomJoinRequest("타콩");
             String content = objectMapper.writeValueAsString(request);

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -186,7 +186,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                             ),
                             responseFields(
                                     fieldWithPath("roomId").type(NUMBER).description("참여한 방 ID"),
-                                    fieldWithPath("roomUuid").type(STRING).description("참여한 방의 UUID"),
+                                    fieldWithPath("roomUuid").type(STRING).description("참여한 방 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -159,7 +159,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
     @Nested
     class 방_참여 {
 
-        private static final String ENDPOINT = "/api/balances/rooms/{roomId}/members";
+        private static final String ENDPOINT = "/api/balances/rooms/{uuid}/members";
 
         @Test
         void 방에_참여한다() throws Exception {
@@ -172,14 +172,14 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             String content = objectMapper.writeValueAsString(request);
 
             //when & then
-            mockMvc.perform(post(ENDPOINT, 1L)
+            mockMvc.perform(post(ENDPOINT, "488fd79f92a34131bf2a628bd58c5d2c")
                             .content(content)
                             .contentType(MediaType.APPLICATION_JSON)
                     )
                     .andExpect(status().isCreated())
                     .andDo(document("room/join",
                             pathParameters(
-                                    parameterWithName("roomId").description("참여방 ID")
+                                    parameterWithName("uuid").description("참여하는 방 UUID")
                             ),
                             requestFields(
                                     fieldWithPath("nickname").description("닉네임")

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -55,14 +55,14 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         void 방을_생성한다() throws Exception {
             // given
             MemberResponse memberResponse = new MemberResponse(1L, "땅콩", true);
-            RoomJoinResponse response = new RoomJoinResponse(1L, memberResponse);
+            RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c", memberResponse);
             when(roomService.createRoom(anyString())).thenReturn(response);
 
             RoomJoinRequest request = new RoomJoinRequest("땅콩");
             String content = objectMapper.writeValueAsString(request);
 
             // when & then
-            mockMvc.perform(post(ENDPOINT, 1L)
+            mockMvc.perform(post(ENDPOINT)
                             .content(content)
                             .contentType(MediaType.APPLICATION_JSON)
                     )
@@ -73,6 +73,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                             ),
                             responseFields(
                                     fieldWithPath("roomId").type(NUMBER).description("생성된 방 ID"),
+                                    fieldWithPath("roomUuid").type(STRING).description("생성된 방의 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")
@@ -163,7 +164,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         @Test
         void 방에_참여한다() throws Exception {
             // given
-            RoomJoinResponse response = new RoomJoinResponse(1L, new MemberResponse(2L, "타콩", false));
+            RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
+                    new MemberResponse(2L, "타콩", false));
             when(roomService.joinRoom(anyString(), anyLong())).thenReturn(response);
 
             RoomJoinRequest request = new RoomJoinRequest("타콩");
@@ -183,7 +185,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("nickname").description("닉네임")
                             ),
                             responseFields(
-                                    fieldWithPath("roomId").type(NUMBER).description("생성된 방 ID"),
+                                    fieldWithPath("roomId").type(NUMBER).description("참여한 방 ID"),
+                                    fieldWithPath("roomUuid").type(STRING).description("참여한 방의 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")

--- a/backend/src/test/java/ddangkong/domain/room/RoomTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/RoomTest.java
@@ -34,7 +34,7 @@ class RoomTest {
         @EnumSource(mode = Mode.EXCLUDE, names = {"READY"})
         void 게임이_이미_시작했다면_예외를_던진다(RoomStatus status) {
             // given
-            Room room = new Room(5, 1, 30_000, status, Category.EXAMPLE);
+            Room room = new Room("uuid", 5, 1, 30_000, status, Category.EXAMPLE);
 
             // when & then
             assertThatThrownBy(room::startGame)
@@ -52,7 +52,7 @@ class RoomTest {
             int totalRound = 5;
             int currentRound = 1;
             int timeLimit = 30_000;
-            Room room = new Room(totalRound, currentRound, timeLimit, RoomStatus.PROGRESS, Category.EXAMPLE);
+            Room room = new Room("uuid", totalRound, currentRound, timeLimit, RoomStatus.PROGRESS, Category.EXAMPLE);
             int expectedRound = currentRound + 1;
 
             // when
@@ -69,7 +69,7 @@ class RoomTest {
             int currentRound = 5;
             int timeLimit = 30_000;
             RoomStatus status = RoomStatus.PROGRESS;
-            Room room = new Room(totalRound, currentRound, timeLimit, status, Category.EXAMPLE);
+            Room room = new Room("uuid", totalRound, currentRound, timeLimit, status, Category.EXAMPLE);
 
             // when
             room.moveToNextRound();
@@ -88,7 +88,7 @@ class RoomTest {
             int totalRound = 5;
             int currentRound = 5;
             int timeLimit = 30_000;
-            Room room = new Room(totalRound, currentRound, timeLimit, status, Category.EXAMPLE);
+            Room room = new Room("uuid", totalRound, currentRound, timeLimit, status, Category.EXAMPLE);
 
             // when & then
             assertThatThrownBy(room::moveToNextRound)
@@ -139,7 +139,7 @@ class RoomTest {
         void 라운드가_방의_현재_라운드보다_작으면_라운드는_종료된_것이다() {
             // given
             int currentRound = 2;
-            Room room = new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
             int round = 1;
 
             // when & then
@@ -150,7 +150,7 @@ class RoomTest {
         void 라운드가_방의_현재_라운드와_같으면_라운드는_종료되지_않은_것이다() {
             // given
             int currentRound = 2;
-            Room room = new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
             int round = 2;
 
             // when & then
@@ -160,7 +160,7 @@ class RoomTest {
         @Test
         void 라운드가_방의_시작_라운드보다_작으면_예외가_발생한다() {
             // given
-            Room room = new Room(TOTAL_ROUND, 1, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, 1, TIME_LIMIT, STATUS, CATEGORY);
             int invalidRound = 0;
 
             // when & then
@@ -173,7 +173,7 @@ class RoomTest {
         void 라운드가_방의_현재_라운드보다_크면_예외가_발생한다() {
             // given
             int currentRound = 1;
-            Room room = new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
             int invalidRound = 2;
 
             // when & then
@@ -186,7 +186,7 @@ class RoomTest {
         void 라운드가_방의_현재_라운드보다_2이상_작으면_예외가_발생한다() {
             // given
             int currentRound = 4;
-            Room room = new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY);
             int invalidRound = 2;
 
             // when & then
@@ -199,7 +199,7 @@ class RoomTest {
         void 현재_라운드와_전체_라운드가_같고_방_상태가_FINISH이면_방의_전체_라운드가_종료된_것이다() {
             // given
             RoomStatus status = RoomStatus.FINISH;
-            Room room = new Room(TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
 
             // when & then
             assertThat(room.isAllRoundFinished()).isTrue();
@@ -210,7 +210,7 @@ class RoomTest {
             // given
             int currentRound = 3;
             int totalRound = 5;
-            Room room = new Room(totalRound, currentRound, TIME_LIMIT, STATUS, CATEGORY);
+            Room room = new Room("uuid", totalRound, currentRound, TIME_LIMIT, STATUS, CATEGORY);
 
             // when & then
             assertThat(room.isAllRoundFinished()).isFalse();
@@ -220,7 +220,7 @@ class RoomTest {
         @EnumSource(mode = Mode.EXCLUDE, names = {"FINISH"})
         void 방_상태가_FINISH가_아니면_현재_라운드가_전체_라운드와_같아도_전체_라운드는_종료되지_않은_것이다(RoomStatus status) {
             // given
-            Room room = new Room(TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
 
             // when & then
             assertThat(room.isAllRoundFinished()).isFalse();
@@ -238,7 +238,7 @@ class RoomTest {
             // given
             int currentRound = 5;
             RoomStatus status = RoomStatus.FINISH;
-            Room room = new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, status, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, status, CATEGORY);
 
             // when
             room.reset();
@@ -254,7 +254,7 @@ class RoomTest {
         void 현재_라운드와_전체_라운드가_같지_않을_경우_예외가_발생한다() {
             // given
             int invalidCurrentRound = 4;
-            Room room = new Room(TOTAL_ROUND, invalidCurrentRound, TIME_LIMIT, RoomStatus.FINISH, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, invalidCurrentRound, TIME_LIMIT, RoomStatus.FINISH, CATEGORY);
 
             // when & then
             assertThatThrownBy(room::reset)
@@ -266,7 +266,7 @@ class RoomTest {
         @EnumSource(mode = Mode.EXCLUDE, names = {"FINISH"})
         void 방_상태가_FINISH가_아닐_경우_예외가_발생한다(RoomStatus status) {
             // given
-            Room room = new Room(TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
+            Room room = new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY);
 
             // when & then
             assertThatThrownBy(room::reset)

--- a/backend/src/test/java/ddangkong/domain/room/balance/roomcontent/RoomContentTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/balance/roomcontent/RoomContentTest.java
@@ -25,7 +25,7 @@ class RoomContentTest {
             // given
             int currentRound = 1;
             int timeLimit = 10_000;
-            Room room = new Room(5, currentRound, timeLimit, RoomStatus.PROGRESS, Category.EXAMPLE);
+            Room room = new Room("uuid", 5, currentRound, timeLimit, RoomStatus.PROGRESS, Category.EXAMPLE);
             RoomContent roomContent = new RoomContent(room, BALANCE_CONTENT, currentRound, null, false);
             int expectedAfterSec = (timeLimit + 2_000) / 1_000;
             LocalDateTime expectedRoundEnded = CURRENT_TIME.plusSeconds(expectedAfterSec);
@@ -41,7 +41,7 @@ class RoomContentTest {
         void 이미_라운드가_시작되었다면_예외를_던진다() {
             // given
             int currentRound = 1;
-            Room room = new Room(5, currentRound, 10_000, RoomStatus.PROGRESS, Category.EXAMPLE);
+            Room room = new Room("uuid", 5, currentRound, 10_000, RoomStatus.PROGRESS, Category.EXAMPLE);
             RoomContent roomContent = new RoomContent(room, BALANCE_CONTENT, currentRound, null, false);
             roomContent.updateRoundEndedAt(CURRENT_TIME, 10_000);
 

--- a/backend/src/test/java/ddangkong/service/room/RoomServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/room/RoomServiceTest.java
@@ -71,13 +71,13 @@ class RoomServiceTest extends BaseServiceTest {
             // given
             String nickname = "나는방장";
             MemberResponse expectedMemberResponse = new MemberResponse(13L, nickname, true);
-            RoomJoinResponse expected = new RoomJoinResponse(8L, expectedMemberResponse);
 
             // when
             RoomJoinResponse actual = roomService.createRoom(nickname);
 
             // then
-            assertThat(actual).isEqualTo(expected);
+            assertThat(actual.roomId()).isEqualTo(8L);
+            assertThat(actual.member()).isEqualTo(expectedMemberResponse);
         }
     }
 
@@ -90,13 +90,13 @@ class RoomServiceTest extends BaseServiceTest {
             String nickname = "나는참가자";
             Long joinRoomId = 4L;
             MemberResponse expectedMemberResponse = new MemberResponse(13L, nickname, false);
-            RoomJoinResponse expected = new RoomJoinResponse(joinRoomId, expectedMemberResponse);
 
             // when
             RoomJoinResponse actual = roomService.joinRoom(nickname, joinRoomId);
 
             // then
-            assertThat(actual).isEqualTo(expected);
+            assertThat(actual.roomId()).isEqualTo(joinRoomId);
+            assertThat(actual.member()).isEqualTo(expectedMemberResponse);
         }
 
         @Test
@@ -225,7 +225,7 @@ class RoomServiceTest extends BaseServiceTest {
         }
 
         Long finalRoundRoomId() {
-            Room room = new Room(5, 5, 30_000, RoomStatus.PROGRESS, Category.EXAMPLE);
+            Room room = new Room("uuid", 5, 5, 30_000, RoomStatus.PROGRESS, Category.EXAMPLE);
             roomRepository.save(room);
             return room.getId();
         }
@@ -314,7 +314,7 @@ class RoomServiceTest extends BaseServiceTest {
             // given
             int currentRound = 2;
             Room room = roomRepository.save(
-                    new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
+                    new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
             int round = 2;
 
             // when
@@ -331,7 +331,7 @@ class RoomServiceTest extends BaseServiceTest {
         void 라운드가_종료되면_게임은_종료되지_않은_상태여야_한다() {
             // given
             int currentRound = 2;
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
             int round = 1;
 
             // when
@@ -349,7 +349,7 @@ class RoomServiceTest extends BaseServiceTest {
             // given
             int currentRound = 5;
             RoomStatus status = RoomStatus.FINISH;
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, status, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, status, CATEGORY));
             int round = 5;
 
             // when
@@ -366,7 +366,7 @@ class RoomServiceTest extends BaseServiceTest {
         void 현재_마지막_라운드여도_게임이_종료되지_않은_상태이면_라운드도_종료되지_않은_상태여야_한다() {
             // given
             int currentRound = 5;
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, currentRound, TIME_LIMIT, STATUS, CATEGORY));
             int round = 5;
 
             // when
@@ -398,7 +398,7 @@ class RoomServiceTest extends BaseServiceTest {
         @Test
         void 방을_초기_상태로_초기화한다() {
             // given
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, 5, TIME_LIMIT, STATUS, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, STATUS, CATEGORY));
             saveRoomContents(room);
 
             // when
@@ -418,7 +418,8 @@ class RoomServiceTest extends BaseServiceTest {
         void 현재_라운드와_전체_라운드가_같지_않을_경우_예외가_발생한다() {
             // given
             int invalidCurrentRound = 4;
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, invalidCurrentRound, TIME_LIMIT, STATUS, CATEGORY));
+            Room room = roomRepository.save(
+                    new Room("uuid", TOTAL_ROUND, invalidCurrentRound, TIME_LIMIT, STATUS, CATEGORY));
             saveRoomContents(room);
 
             // when & then
@@ -431,7 +432,7 @@ class RoomServiceTest extends BaseServiceTest {
         @EnumSource(mode = Mode.EXCLUDE, names = {"FINISH"})
         void 방_상태가_FINISH가_아닐_경우_예외가_발생한다(RoomStatus status) {
             // given
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, status, CATEGORY));
             saveRoomContents(room);
 
             // when & then
@@ -451,7 +452,7 @@ class RoomServiceTest extends BaseServiceTest {
             // given
             BalanceOption optionA = balanceOptionRepository.save(new BalanceOption("A", content));
             BalanceOption optionB = balanceOptionRepository.save(new BalanceOption("B", content));
-            Room room = roomRepository.save(new Room(TOTAL_ROUND, 5, TIME_LIMIT, STATUS, CATEGORY));
+            Room room = roomRepository.save(new Room("uuid", TOTAL_ROUND, 5, TIME_LIMIT, STATUS, CATEGORY));
             Member prin = memberRepository.save(PRIN.master(room));
             Member eden = memberRepository.save(EDEN.common(room));
             Member keochan = memberRepository.save(KEOCHAN.common(room));

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -21,14 +21,14 @@ INSERT INTO total_balance_vote(balance_option_id)
 VALUES (1),
        (2);
 
-INSERT INTO room (total_round, current_round, time_limit, status, category)
-VALUES (5, 2, 30000, 'PROGRESS', 'EXAMPLE'),
-       (5, 1, 30000, 'PROGRESS', 'EXAMPLE'),
-       (5, 1, 30000, 'PROGRESS', 'EXAMPLE'),
-       (3, 1, 30000, 'READY', 'EXAMPLE'),
-       (3, 1, 30000, 'FINISH', 'EXAMPLE'),
-       (3, 1, 30000, 'FINISH', 'EXAMPLE'),
-       (3, 1, 30000, 'READY', 'EXAMPLE');
+INSERT INTO room (uuid, total_round, current_round, time_limit, status, category)
+VALUES ('uuid1', 5, 2, 30000, 'PROGRESS', 'EXAMPLE'),
+       ('uuid2', 5, 1, 30000, 'PROGRESS', 'EXAMPLE'),
+       ('uuid3', 5, 1, 30000, 'PROGRESS', 'EXAMPLE'),
+       ('uuid4', 3, 1, 30000, 'READY', 'EXAMPLE'),
+       ('uuid5', 3, 1, 30000, 'FINISH', 'EXAMPLE'),
+       ('uuid6', 3, 1, 30000, 'FINISH', 'EXAMPLE'),
+       ('uuid7', 3, 1, 30000, 'READY', 'EXAMPLE');
 
 INSERT INTO member (nickname, room_id, is_master)
 VALUES ('mohamedeu al katan', 1, true),


### PR DESCRIPTION
## Issue Number
close #191 

## As-Is
<!-- 문제 상황 정의 -->
게임 방에 접속할 때, 방의 PK를 통해 접속하기 때문에 외부에서 아무런 방이나 숫자만 바꾸면 마음껏 접속이 가능하다.

## To-Be
<!-- 변경 사항 -->
이러한 문제를 막기 위해 방 아이디를 사용하던 기존 방식을 UUID를 사용하도록 변경한다.

현재는 Join만 UUID로 다루는 이유
지금은 roomId만 알면 room과 관련된 특정 동작들을 수행시킬 수 있지만
memberId를 쿠키를 통해 받는 로직을 이번 4차 스프린트 과정에서 추가하면서,
요청을 보낸 member가 특정 방에 속해있는 member가 맞아야 요청을 수행할 수 있도록 처리한다면(다음 PR이 될 것 같네요)
사실상 방의 UUID를 통해 입장한 회원이 아니면 roomId를 알아도 무언가 할 수 없으니
일단 요정도로 괜찮을 것 같다고 생각했다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="877" alt="스크린샷 2024-08-18 21 49 08" src="https://github.com/user-attachments/assets/122bc558-a8b1-420e-814e-d63e1845d430">
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/f6cef0f5-c676-463e-afcd-113ec941f7d6">
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/1f76ac24-fa10-4cdf-8147-82f5e5a677af">


## (Optional) Additional Description
- 방 join, 방 create API에서 roomId 뿐만 아니라 uuid도 함께 Response하게 되면서 
하나의 ResponseDTO객체에 담아야할 지 고민이 됐습니다만 프론트엔드 수정을 최소화하기 위해 고민만 하고 건드리진 않았습니다. 의견 부탁드려요~!
- 방 참여 API의 RestDocs에 roomId에 대한 설명이 "생성한 방의 ID"로 되어 있어서 "참여한 방"으로 변경하였습니다.