### PR TITLE
[FEAT] 선택지별 투표 결과 API 호출 시, 기권자 정보도 함께 조회

### DIFF
--- a/backend/src/main/java/ddangkong/domain/room/balance/roomvote/RoomBalanceVoteRepository.java
+++ b/backend/src/main/java/ddangkong/domain/room/balance/roomvote/RoomBalanceVoteRepository.java
@@ -1,5 +1,6 @@
 package ddangkong.domain.room.balance.roomvote;
 
+import ddangkong.domain.balance.content.BalanceContent;
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.room.Room;
 import ddangkong.domain.room.member.Member;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RoomBalanceVoteRepository extends JpaRepository<RoomBalanceVote, Long> {
 
     List<RoomBalanceVote> findByMemberRoomAndBalanceOption(Room room, BalanceOption balanceOption);
+
+    List<RoomBalanceVote> findByMemberRoomAndBalanceOptionBalanceContent(Room room, BalanceContent balanceContent);
 
     long countByMemberInAndBalanceOptionIn(List<Member> members, List<BalanceOption> balanceOptions);
 

--- a/backend/src/main/java/ddangkong/domain/room/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/room/member/Member.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,5 +45,22 @@ public class Member {
 
     public static Member createCommon(String nickname, Room room) {
         return new Member(nickname, room, false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
+++ b/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
@@ -3,7 +3,9 @@ package ddangkong.facade.balance.vote.dto;
 import ddangkong.domain.room.member.Member;
 import java.util.List;
 
-public record GiveUpVoteMemberResponse(List<String> members, int memberCount) {
+public record GiveUpVoteMemberResponse(
+        List<String> members,
+        int memberCount) {
 
     public static GiveUpVoteMemberResponse create(List<Member> giveUpMembers) {
         List<String> members = giveUpMembers.stream()

--- a/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
+++ b/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
@@ -1,0 +1,16 @@
+package ddangkong.facade.balance.vote.dto;
+
+import ddangkong.domain.room.member.Member;
+import java.util.List;
+
+public record GiveUpVoteMemberResponse(List<String> members, int memberCount) {
+
+    public static GiveUpVoteMemberResponse create(List<Member> giveUpMembers) {
+        List<String> members = giveUpMembers.stream()
+                .map(Member::getNickname)
+                .toList();
+        int memberCount = giveUpMembers.size();
+
+        return new GiveUpVoteMemberResponse(members, memberCount);
+    }
+}

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
@@ -78,9 +78,9 @@ public class RoomBalanceVoteFacade {
 
     private ContentRoomBalanceVoteResponse getContentRoomBalanceVoteResponse(Room room, BalanceOptions balanceOptions) {
         List<RoomBalanceVote> firstOptionVotes = roomBalanceVoteService
-                .getVotesInRoom(room, balanceOptions.getFirstOption());
+                .getVotesInRoomByOption(room, balanceOptions.getFirstOption());
         List<RoomBalanceVote> secondOptionVotes = roomBalanceVoteService
-                .getVotesInRoom(room, balanceOptions.getSecondOption());
+                .getVotesInRoomByOption(room, balanceOptions.getSecondOption());
         return ContentRoomBalanceVoteResponse.create(balanceOptions, firstOptionVotes, secondOptionVotes);
     }
 

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
@@ -73,8 +73,7 @@ public class RoomBalanceVoteFacade {
 
         BalanceOptions balanceOptions = balanceOptionService.getBalanceOptions(balanceContent);
 
-        List<Member> giveUpMembers = getGiveUpVoteMemberResponse(room, balanceContent);
-        ContentRoomBalanceVoteResponse group = getContentRoomBalanceVoteResponse(room, balanceOptions, giveUpMembers);
+        ContentRoomBalanceVoteResponse group = getContentRoomBalanceVoteResponse(room, balanceOptions, balanceContent);
         ContentTotalBalanceVoteResponse total = getContentTotalBalanceVoteResponse(balanceOptions);
 
         return new RoomBalanceVoteResultResponse(group, total);
@@ -96,7 +95,8 @@ public class RoomBalanceVoteFacade {
 
     private ContentRoomBalanceVoteResponse getContentRoomBalanceVoteResponse(Room room,
                                                                              BalanceOptions balanceOptions,
-                                                                             List<Member> giveUpMembers) {
+                                                                             BalanceContent balanceContent) {
+        List<Member> giveUpMembers = getGiveUpVoteMemberResponse(room, balanceContent);
         List<RoomBalanceVote> firstOptionVotes = roomBalanceVoteService
                 .getVotesInRoomByOption(room, balanceOptions.getFirstOption());
         List<RoomBalanceVote> secondOptionVotes = roomBalanceVoteService

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
@@ -94,15 +94,19 @@ public class RoomBalanceVoteFacade {
 
     private List<Member> getGiveUpVoteMemberResponse(Room room, BalanceContent balanceContent) {
         List<Member> roomMembers = memberService.findRoomMembers(room);
-        List<RoomBalanceVote> votesInRoomByContent = roomBalanceVoteService.getVotesInRoomByContent(room,
-                balanceContent);
-
-        List<Member> voteMembers = votesInRoomByContent.stream()
-                .map(RoomBalanceVote::getMember)
-                .toList();
+        List<Member> voteMembers = getVoteMembers(room, balanceContent);
 
         return roomMembers.stream()
                 .filter(roomMember -> !voteMembers.contains(roomMember))
+                .toList();
+    }
+
+    private List<Member> getVoteMembers(Room room, BalanceContent balanceContent) {
+        List<RoomBalanceVote> votesInRoomByContent = roomBalanceVoteService.getVotesInRoomByContent(room,
+                balanceContent);
+
+        return votesInRoomByContent.stream()
+                .map(RoomBalanceVote::getMember)
                 .toList();
     }
 

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
@@ -79,6 +79,19 @@ public class RoomBalanceVoteFacade {
         return new RoomBalanceVoteResultResponse(group, total);
     }
 
+    private ContentRoomBalanceVoteResponse getContentRoomBalanceVoteResponse(Room room,
+                                                                             BalanceOptions balanceOptions,
+                                                                             BalanceContent balanceContent) {
+        List<Member> giveUpMembers = getGiveUpVoteMemberResponse(room, balanceContent);
+        List<RoomBalanceVote> firstOptionVotes = roomBalanceVoteService
+                .getVotesInRoomByOption(room, balanceOptions.getFirstOption());
+        List<RoomBalanceVote> secondOptionVotes = roomBalanceVoteService
+                .getVotesInRoomByOption(room, balanceOptions.getSecondOption());
+
+        return ContentRoomBalanceVoteResponse.create(balanceOptions, firstOptionVotes, secondOptionVotes,
+                giveUpMembers);
+    }
+
     private List<Member> getGiveUpVoteMemberResponse(Room room, BalanceContent balanceContent) {
         List<Member> roomMembers = memberService.findRoomMembers(room);
         List<RoomBalanceVote> votesInRoomByContent = roomBalanceVoteService.getVotesInRoomByContent(room,
@@ -91,19 +104,6 @@ public class RoomBalanceVoteFacade {
         return roomMembers.stream()
                 .filter(roomMember -> !voteMembers.contains(roomMember))
                 .toList();
-    }
-
-    private ContentRoomBalanceVoteResponse getContentRoomBalanceVoteResponse(Room room,
-                                                                             BalanceOptions balanceOptions,
-                                                                             BalanceContent balanceContent) {
-        List<Member> giveUpMembers = getGiveUpVoteMemberResponse(room, balanceContent);
-        List<RoomBalanceVote> firstOptionVotes = roomBalanceVoteService
-                .getVotesInRoomByOption(room, balanceOptions.getFirstOption());
-        List<RoomBalanceVote> secondOptionVotes = roomBalanceVoteService
-                .getVotesInRoomByOption(room, balanceOptions.getSecondOption());
-
-        return ContentRoomBalanceVoteResponse.create(balanceOptions, firstOptionVotes, secondOptionVotes,
-                giveUpMembers);
     }
 
     private ContentTotalBalanceVoteResponse getContentTotalBalanceVoteResponse(BalanceOptions balanceOptions) {

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/ContentRoomBalanceVoteResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/ContentRoomBalanceVoteResponse.java
@@ -3,23 +3,28 @@ package ddangkong.facade.room.balance.roomvote.dto;
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.balance.option.BalanceOptions;
 import ddangkong.domain.room.balance.roomvote.RoomBalanceVote;
+import ddangkong.domain.room.member.Member;
+import ddangkong.facade.balance.vote.dto.GiveUpVoteMemberResponse;
 import java.util.List;
 
 public record ContentRoomBalanceVoteResponse(
         OptionRoomBalanceVoteResponse firstOption,
-        OptionRoomBalanceVoteResponse secondOption
+        OptionRoomBalanceVoteResponse secondOption,
+        GiveUpVoteMemberResponse giveUp
 ) {
 
     public static ContentRoomBalanceVoteResponse create(BalanceOptions balanceOptions,
                                                         List<RoomBalanceVote> firstOptionVotes,
-                                                        List<RoomBalanceVote> secondOptionVotes) {
+                                                        List<RoomBalanceVote> secondOptionVotes,
+                                                        List<Member> giveUpMembers) {
         BalanceOption fistOption = balanceOptions.getFirstOption();
         BalanceOption secondOption = balanceOptions.getSecondOption();
         int contentVoteCount = firstOptionVotes.size() + secondOptionVotes.size();
 
         return new ContentRoomBalanceVoteResponse(
                 OptionRoomBalanceVoteResponse.create(fistOption, firstOptionVotes, contentVoteCount),
-                OptionRoomBalanceVoteResponse.create(secondOption, secondOptionVotes, contentVoteCount)
+                OptionRoomBalanceVoteResponse.create(secondOption, secondOptionVotes, contentVoteCount),
+                GiveUpVoteMemberResponse.create(giveUpMembers)
         );
     }
 }

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
@@ -1,5 +1,6 @@
 package ddangkong.service.room.balance.roomvote;
 
+import ddangkong.domain.balance.content.BalanceContent;
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.balance.option.BalanceOptions;
 import ddangkong.domain.room.Room;
@@ -49,5 +50,10 @@ public class RoomBalanceVoteService {
     @Transactional(readOnly = true)
     public List<RoomBalanceVote> getVotesInRoomByOption(Room room, BalanceOption balanceOption) {
         return roomVoteRepository.findByMemberRoomAndBalanceOption(room, balanceOption);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoomBalanceVote> getVotesInRoomByContent(Room room, BalanceContent balanceContent) {
+        return roomVoteRepository.findByMemberRoomAndBalanceOptionBalanceContent(room, balanceContent);
     }
 }

--- a/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomvote/RoomBalanceVoteService.java
@@ -47,7 +47,7 @@ public class RoomBalanceVoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<RoomBalanceVote> getVotesInRoom(Room room, BalanceOption balanceOption) {
+    public List<RoomBalanceVote> getVotesInRoomByOption(Room room, BalanceOption balanceOption) {
         return roomVoteRepository.findByMemberRoomAndBalanceOption(room, balanceOption);
     }
 }

--- a/backend/src/main/java/ddangkong/util/PercentageCalculator.java
+++ b/backend/src/main/java/ddangkong/util/PercentageCalculator.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 public class PercentageCalculator {
 
     private static final double SECOND_DECIMAL_PLACE_ROUNDING_FACTOR = 100.0;
-    private static final int DEFAULT_PERCENTAGE = 50;
+    private static final int NON_TOTAL_COUNT_PERCENTAGE = 0;
 
     public static int calculatePercent(long count, long totalCount) {
         if (count < 0) {
@@ -19,7 +19,7 @@ public class PercentageCalculator {
         }
 
         if (totalCount == 0) {
-            return DEFAULT_PERCENTAGE;
+            return NON_TOTAL_COUNT_PERCENTAGE;
         }
         return (int) Math.round(count * SECOND_DECIMAL_PLACE_ROUNDING_FACTOR / totalCount);
     }

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -76,7 +76,7 @@ class RoomControllerTest extends BaseControllerTest {
 
             //then
             assertAll(
-                    () -> Assertions.assertThat(actual.members()).hasSize(4),
+                    () -> Assertions.assertThat(actual.members()).hasSize(5),
                     () -> Assertions.assertThat(actual.isGameStart()).isTrue(),
                     () -> Assertions.assertThat(actual.roomSetting().timeLimit()).isEqualTo(30000),
                     () -> Assertions.assertThat(actual.roomSetting().totalRound()).isEqualTo(5)

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ddangkong.controller.room.balance.roomvote.RoomBalanceVoteController;
 import ddangkong.documentation.BaseDocumentationTest;
 import ddangkong.facade.balance.vote.dto.ContentTotalBalanceVoteResponse;
+import ddangkong.facade.balance.vote.dto.GiveUpVoteMemberResponse;
 import ddangkong.facade.balance.vote.dto.OptionTotalBalanceVoteResponse;
 import ddangkong.facade.room.balance.roomvote.RoomBalanceVoteFacade;
 import ddangkong.facade.room.balance.roomvote.dto.ContentRoomBalanceVoteResponse;
@@ -58,9 +59,13 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                     List.of("rapper lee"), 1, 25);
             OptionTotalBalanceVoteResponse firstTotalResponse = new OptionTotalBalanceVoteResponse(1L, "민초", 50);
             OptionTotalBalanceVoteResponse secondTotalResponse = new OptionTotalBalanceVoteResponse(2L, "반민초", 50);
+            GiveUpVoteMemberResponse giveUpVoteMemberResponse = new GiveUpVoteMemberResponse(List.of("jason"), 1);
+
             RoomBalanceVoteResultResponse response = new RoomBalanceVoteResultResponse(
-                    new ContentRoomBalanceVoteResponse(firstGroupResponse, secondGroupResponse),
-                    new ContentTotalBalanceVoteResponse(firstTotalResponse, secondTotalResponse));
+                    new ContentRoomBalanceVoteResponse(firstGroupResponse, secondGroupResponse,
+                            giveUpVoteMemberResponse),
+                    new ContentTotalBalanceVoteResponse(firstTotalResponse, secondTotalResponse)
+            );
             when(roomBalanceVoteFacade.getAllVoteResult(roomId, contentId)).thenReturn(response);
 
             // when & then
@@ -90,6 +95,11 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                                     .description("선택지를 선택한 사람 수"),
                                             fieldWithPath("group.secondOption.percent").type(NUMBER)
                                                     .description("선택지를 선택한 퍼센트"),
+                                            fieldWithPath("group.giveUp").type(OBJECT).description("기권한 멤버 정보"),
+                                            fieldWithPath("group.giveUp.members").type(ARRAY)
+                                                    .description("기권한 멤버 이름들"),
+                                            fieldWithPath("group.giveUp.memberCount").type(NUMBER)
+                                                    .description("기권한 멤버 수"),
                                             fieldWithPath("total").type(OBJECT).description("전체 유저 결과"),
                                             fieldWithPath("total.firstOption").type(OBJECT).description("전체 유저 첫 번째 선택지 결과"),
                                             fieldWithPath("total.firstOption.optionId").type(NUMBER).description("선택지 ID"),

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
@@ -82,7 +82,7 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             fieldWithPath("group.firstOption.optionId").type(NUMBER).description("선택지 ID"),
                                             fieldWithPath("group.firstOption.name").type(STRING).description("선택지 이름"),
                                             fieldWithPath("group.firstOption.members").type(ARRAY)
-                                                    .description("선택지를 선택한 멤버 이름들"),
+                                                    .description("선택지를 선택한 멤버들의 닉네임"),
                                             fieldWithPath("group.firstOption.memberCount").type(NUMBER)
                                                     .description("선택지를 선택한 사람 수"),
                                             fieldWithPath("group.firstOption.percent").type(NUMBER).description("선택지를 선택한 퍼센트"),
@@ -90,14 +90,14 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             fieldWithPath("group.secondOption.optionId").type(NUMBER).description("선택지 ID"),
                                             fieldWithPath("group.secondOption.name").type(STRING).description("선택지 이름"),
                                             fieldWithPath("group.secondOption.members").type(ARRAY)
-                                                    .description("선택지를 선택한 멤버 이름들"),
+                                                    .description("선택지를 선택한 멤버들의 닉네임"),
                                             fieldWithPath("group.secondOption.memberCount").type(NUMBER)
                                                     .description("선택지를 선택한 사람 수"),
                                             fieldWithPath("group.secondOption.percent").type(NUMBER)
                                                     .description("선택지를 선택한 퍼센트"),
                                             fieldWithPath("group.giveUp").type(OBJECT).description("기권한 멤버 정보"),
                                             fieldWithPath("group.giveUp.members").type(ARRAY)
-                                                    .description("기권한 멤버 이름들"),
+                                                    .description("기권한 멤버들의 닉네임"),
                                             fieldWithPath("group.giveUp.memberCount").type(NUMBER)
                                                     .description("기권한 멤버 수"),
                                             fieldWithPath("total").type(OBJECT).description("전체 유저 결과"),

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -44,7 +44,7 @@ class RoomFacadeTest extends BaseServiceTest {
         void 방_생성_시_방장_멤버를_생성하고_방을_생성한다() {
             // given
             String nickname = "나는방장";
-            MemberResponse expectedMemberResponse = new MemberResponse(13L, nickname, true);
+            MemberResponse expectedMemberResponse = new MemberResponse(14L, nickname, true);
 
             // when
             RoomJoinResponse actual = roomFacade.createRoom(nickname);
@@ -63,7 +63,7 @@ class RoomFacadeTest extends BaseServiceTest {
             // given
             String nickname = "나는참가자";
             String uuid = "uuid4";
-            MemberResponse expectedMemberResponse = new MemberResponse(13L, nickname, false);
+            MemberResponse expectedMemberResponse = new MemberResponse(14L, nickname, false);
 
             // when
             RoomJoinResponse actual = roomFacade.joinRoom(nickname, uuid);

--- a/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
@@ -17,6 +17,7 @@ import ddangkong.domain.room.member.Member;
 import ddangkong.exception.BadRequestException;
 import ddangkong.facade.BaseServiceTest;
 import ddangkong.facade.balance.vote.dto.ContentTotalBalanceVoteResponse;
+import ddangkong.facade.balance.vote.dto.GiveUpVoteMemberResponse;
 import ddangkong.facade.balance.vote.dto.OptionTotalBalanceVoteResponse;
 import ddangkong.facade.room.balance.roomvote.dto.ContentRoomBalanceVoteResponse;
 import ddangkong.facade.room.balance.roomvote.dto.OptionRoomBalanceVoteResponse;
@@ -147,7 +148,8 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
                                     3, 75),
                             new OptionRoomBalanceVoteResponse(2L,
                                     "반민초",
-                                    List.of("rapper lee"), 1, 25)
+                                    List.of("rapper lee"), 1, 25),
+                            new GiveUpVoteMemberResponse(List.of("giveUpMember"), 1)
                     ),
                     new ContentTotalBalanceVoteResponse(
                             new OptionTotalBalanceVoteResponse(1L, "민초", 50),

--- a/backend/src/test/java/ddangkong/util/PercentageCalculatorTest.java
+++ b/backend/src/test/java/ddangkong/util/PercentageCalculatorTest.java
@@ -31,7 +31,7 @@ class PercentageCalculatorTest {
         int percent = PercentageCalculator.calculatePercent(count, totalCount);
 
         // then
-        assertThat(percent).isEqualTo(50);
+        assertThat(percent).isEqualTo(0);
     }
 
     @Test

--- a/backend/src/test/resources/init-test.sql
+++ b/backend/src/test/resources/init-test.sql
@@ -42,7 +42,8 @@ VALUES ('mohamedeu al katan', 1, true),
        ('pomae', 3, false),
        ('ready player', 4, true),
        ('finish player', 5, true),
-       ('master', 6, true);
+       ('master', 6, true),
+       ('giveUpMember', 1, false);
 
 INSERT INTO room_content (room_id, balance_content_id, round, round_ended_at)
 VALUES (1, 2, 1, '2024-07-18 19:50:32.000'),


### PR DESCRIPTION
## Issue Number
close #208


## As-Is
<!-- 문제 상황 정의 -->
선택지 별 투표 결과 조회 시 기권자 정보가 표시되지 않아 누가 기권했는 지 확인할 수 없다.

## To-Be
<!-- 변경 사항 -->
 선택지별 투표 결과 API Response DTO에 기권자 정보 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="698" alt="스크린샷 2024-08-19 19 49 22" src="https://github.com/user-attachments/assets/1b036963-31ab-4a9e-a7c9-c3d69d7825b0">


## (Optional) Additional Description
- https://www.notion.so/ghenmaru/API-09fecba367f449b1b37c0a80d8f1dded?pvs=4
- RestDocs 문서가 `./gradlew bootJar -DcreateRestDocs` 로 아티팩트 파일을 만들어 실행해도 뜨지 않네요 확인 한 번 부탁드립니다!