### PR TITLE
[FIX] 방 정보 조회 응답에 카테고리 DTO추가

### DIFF
--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomSettingResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomSettingResponse.java
@@ -1,15 +1,15 @@
 package ddangkong.facade.room.dto;
 
-import ddangkong.domain.balance.content.Category;
 import ddangkong.domain.room.Room;
+import ddangkong.facade.balance.content.BalanceCategoryResponse;
 
 public record RoomSettingResponse(
         int totalRound,
         int timeLimit,
-        Category category
+        BalanceCategoryResponse category
 ) {
 
     public RoomSettingResponse(Room room) {
-        this(room.getTotalRound(), room.getTimeLimit(), room.getCategory());
+        this(room.getTotalRound(), room.getTimeLimit(), BalanceCategoryResponse.create(room.getCategory()));
     }
 }

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ddangkong.controller.room.RoomController;
 import ddangkong.documentation.BaseDocumentationTest;
 import ddangkong.domain.balance.content.Category;
+import ddangkong.facade.balance.content.BalanceCategoryResponse;
 import ddangkong.facade.room.RoomFacade;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.InitialRoomResponse;
@@ -95,10 +96,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         @Test
         void 방_정보를_조회한다() throws Exception {
             // given
-            int totalRound = 5;
-            int timeLimit = 10_000;
             Category category = Category.IF;
-            RoomSettingResponse roomSetting = new RoomSettingResponse(5, 30, category);
+            RoomSettingResponse roomSetting = new RoomSettingResponse(5, 30, BalanceCategoryResponse.create(category));
             List<MemberResponse> members = List.of(
                     new MemberResponse(1L, "땅콩", true),
                     new MemberResponse(2L, "타콩", false)
@@ -119,7 +118,9 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("roomSetting").type(OBJECT).description("현재 방 설정 값"),
                                     fieldWithPath("roomSetting.totalRound").type(NUMBER).description("전체 라운드"),
                                     fieldWithPath("roomSetting.timeLimit").type(NUMBER).description("라운드 당 시간제한(ms)"),
-                                    fieldWithPath("roomSetting.category").type(STRING).description("컨텐츠 카테고리"),
+                                    fieldWithPath("roomSetting.category").type(OBJECT).description("컨텐츠 카테고리"),
+                                    fieldWithPath("roomSetting.category.value").type(STRING).description("카테고리 값"),
+                                    fieldWithPath("roomSetting.category.label").type(STRING).description("카테고리 표기"),
                                     fieldWithPath("members").type(ARRAY).description("방에 참여중 인원 목록"),
                                     fieldWithPath("members[].memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("members[].nickname").type(STRING).description("멤버 닉네임"),


### PR DESCRIPTION
## Issue Number
close #232 

## As-Is
<!-- 문제 상황 정의 -->
- 카테고리 응답 방식이 '방 정보 조회 API' 와 '카테고리 조회 API' 둘이 서로 달라 통일 시켜줌

## To-Be
<!-- 변경 사항 -->
-  '방 정보 조회 API'에서 카테고리 응답을 단순 문자열에서 DTO로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="815" alt="image" src="https://github.com/user-attachments/assets/0d798966-a791-4287-bb54-a720b50daec5">