### PR TITLE
[FIX] RoomContentResponse 카테고리 응답 값 변경 #232

### DIFF
--- a/backend/src/main/java/ddangkong/facade/room/balance/roomcontent/dto/RoomContentResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomcontent/dto/RoomContentResponse.java
@@ -1,14 +1,13 @@
 package ddangkong.facade.room.balance.roomcontent.dto;
 
 import ddangkong.domain.balance.content.BalanceContent;
-import ddangkong.domain.balance.content.Category;
 import ddangkong.domain.balance.option.BalanceOptions;
 import ddangkong.domain.room.Room;
 import ddangkong.facade.balance.option.dto.BalanceOptionResponse;
 
 public record RoomContentResponse(
         Long contentId,
-        Category category,
+        String category,
         int totalRound,
         int currentRound,
         int timeLimit,
@@ -19,7 +18,7 @@ public record RoomContentResponse(
 
     public RoomContentResponse(Room room, BalanceContent balanceContent, BalanceOptions balanceOptions) {
         this(balanceContent.getId(),
-                balanceContent.getCategory(),
+                balanceContent.getCategory().getValue(),
                 room.getTotalRound(),
                 room.getCurrentRound(),
                 room.getTimeLimit(),

--- a/backend/src/test/java/ddangkong/controller/room/balance/roomcontent/RoomContentControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/balance/roomcontent/RoomContentControllerTest.java
@@ -17,7 +17,7 @@ class RoomContentControllerTest extends BaseControllerTest {
 
         private static final RoomContentResponse EXPECTED_RESPONSE = new RoomContentResponse(
                 1L,
-                Category.IF,
+                Category.IF.getValue(),
                 5,
                 2,
                 10_000, // TODO 추후 sec으로 변경

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomcontent/RoomContentDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomcontent/RoomContentDocumentationTest.java
@@ -41,7 +41,7 @@ class RoomContentDocumentationTest extends BaseDocumentationTest {
             BalanceOptionResponse secondOptionResponse = new BalanceOptionResponse(2L, "100억 부자 송강호");
             RoomContentResponse response = new RoomContentResponse(
                     1L,
-                    Category.IF,
+                    Category.IF.getValue(),
                     5,
                     2,
                     10_000, // TODO sec 단위로 수정

--- a/backend/src/test/java/ddangkong/facade/room/balance/roomcontent/RoomContentFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/balance/roomcontent/RoomContentFacadeTest.java
@@ -27,7 +27,7 @@ class RoomContentFacadeTest extends BaseServiceTest {
         private static final Long FINISHED_ROOM_ID = 5L;
         private static final RoomContentResponse BALANCE_CONTENT_RESPONSE = new RoomContentResponse(
                 1L,
-                Category.IF,
+                Category.IF.getValue(),
                 5,
                 2,
                 10_000, // TODO 추후 sec으로 변경


### PR DESCRIPTION
## Issue Number
close #239 

## As-Is
<!-- 문제 상황 정의 -->
- RoomContentResponse 에서는 Enum 을 그대로 받고 있어서 "ROMANCE"로 가고 응답하고 있었다

## To-Be
<!-- 변경 사항 -->
- RoomContentResponse 에서 Category의 표시 값인 "연애"를 보내주도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="701" alt="image" src="https://github.com/user-attachments/assets/162182ce-d9f1-40f8-9bdc-ecdc0b7c705c">


## (Optional) Additional Description
