### PR TITLE
fix: 잘못된 에러 로그 제거 #235

### DIFF
--- a/backend/src/main/java/ddangkong/service/room/balance/roomcontent/RoomContentService.java
+++ b/backend/src/main/java/ddangkong/service/room/balance/roomcontent/RoomContentService.java
@@ -50,11 +50,6 @@ public class RoomContentService {
     public void deleteRoomContents(Room room) {
         List<RoomContent> roomContents = roomContentRepository.findAllByRoom(room);
         roomContentRepository.deleteAllInBatch(roomContents);
-
-        if (room.getTotalRound() != roomContents.size()) {
-            log.error("방의 총 라운드와 방 컨텐츠 개수가 일치하지 않습니다. roomId: {}, totalRound: {}, roomContent 개수: {}",
-                    room.getId(), room.getTotalRound(), roomContents.size());
-        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Issue Number
#235 

## As-Is
<!-- 문제 상황 정의 -->
<img width="1048" alt="스크린샷 2024-08-23 10 04 39" src="https://github.com/user-attachments/assets/9a481596-894a-417d-9f6c-d48a60f3b206">

애초에 Room이 Start하기 전에는 RoomContent가 0이기 때문에
게임 도중이 아닌, Ready상태인 Room에서 모든 멤버가 나가면 무조건 해당 에러 로그가 찍힌다.

## To-Be
<!-- 변경 사항 -->
```java
    @Transactional
    public void deleteRoomContents(Room room) {
        List<RoomContent> roomContents = roomContentRepository.findAllByRoom(room);
        roomContentRepository.deleteAllInBatch(roomContents);

        if (room.getTotalRound() != roomContents.size()) {
            log.error("방의 총 라운드와 방 컨텐츠 개수가 일치하지 않습니다. roomId: {}, totalRound: {}, roomContent 개수: {}",
                    room.getId(), room.getTotalRound(), roomContents.size());
        }
    }
```

해당 메서드의 log.error를 제거한다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
