### PR TITLE
[FIX] Deprecated된 dialect설정 제거 후 새로운 버전으로 변경

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
       mode: never
 
   jpa:
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: none
     properties:


### PR DESCRIPTION
## Issue Number
close #256 

## As-Is
<!-- 문제 상황 정의 -->
Deprecated된 MySQL8 dialect설정을 최신 dialect 설정으로 변경한다. (근거 자료는 이슈 참조바랍니다.)

## To-Be
<!-- 변경 사항 -->
Deprecated된 `org.hibernate.dialect.MySQL8Dialect` 대신 `org.hibernate.dialect.MySQLDialect` 를 사용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
