### PR TITLE
[REFACTOR] Polling API dev환경에서만 로깅하도록 리팩토링

### DIFF
--- a/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Component;
 public class DevRequestLoggingAspect extends RequestLoggingAspect {
     @Before("allController()")
     public void logController(JoinPoint joinPoint) {
-        logRequest(joinPoint);
+        super.logController(joinPoint);
     }
 }

--- a/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
@@ -1,0 +1,27 @@
+package ddangkong.aop.logging;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Profile({"dev", "local"})
+public class DevRequestLoggingAspect extends RequestLoggingAspect {
+    @Before("allController()")
+    public void logController(JoinPoint joinPoint) {
+        HttpServletRequest request = getHttpServletRequest();
+        String uri = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String queryParameters = getQueryParameters(request);
+        String body = getBody(joinPoint);
+
+        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
+    }
+}

--- a/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
@@ -1,7 +1,6 @@
 package ddangkong.aop.logging;
 
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -16,12 +15,6 @@ import org.springframework.stereotype.Component;
 public class DevRequestLoggingAspect extends RequestLoggingAspect {
     @Before("allController()")
     public void logController(JoinPoint joinPoint) {
-        HttpServletRequest request = getHttpServletRequest();
-        String uri = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        String queryParameters = getQueryParameters(request);
-        String body = getBody(joinPoint);
-
-        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
+        logRequest(joinPoint);
     }
 }

--- a/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/DevRequestLoggingAspect.java
@@ -1,14 +1,12 @@
 package ddangkong.aop.logging;
 
 
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Aspect
 @Component
 @Profile({"dev", "local"})

--- a/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Component;
 public class ProdRequestLoggingAspect extends RequestLoggingAspect {
     @Before("allControllerWithoutPolling()")
     public void logController(JoinPoint joinPoint) {
-        logRequest(joinPoint);
+        super.logController(joinPoint);
     }
 }

--- a/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
@@ -1,7 +1,6 @@
 package ddangkong.aop.logging;
 
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -16,12 +15,6 @@ import org.springframework.stereotype.Component;
 public class ProdRequestLoggingAspect extends RequestLoggingAspect {
     @Before("allControllerWithoutPolling()")
     public void logController(JoinPoint joinPoint) {
-        HttpServletRequest request = getHttpServletRequest();
-        String uri = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        String queryParameters = getQueryParameters(request);
-        String body = getBody(joinPoint);
-
-        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
+        logRequest(joinPoint);
     }
 }

--- a/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
@@ -1,14 +1,12 @@
 package ddangkong.aop.logging;
 
 
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Aspect
 @Component
 @Profile("prod")

--- a/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ProdRequestLoggingAspect.java
@@ -1,0 +1,27 @@
+package ddangkong.aop.logging;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Profile("prod")
+public class ProdRequestLoggingAspect extends RequestLoggingAspect {
+    @Before("allControllerWithoutPolling()")
+    public void logController(JoinPoint joinPoint) {
+        HttpServletRequest request = getHttpServletRequest();
+        String uri = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String queryParameters = getQueryParameters(request);
+        String body = getBody(joinPoint);
+
+        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
+    }
+}

--- a/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
@@ -6,14 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-@Aspect
 @Slf4j
 abstract class RequestLoggingAspect {
 
@@ -29,7 +27,11 @@ abstract class RequestLoggingAspect {
     public void allControllerWithoutPolling() {
     }
 
-    protected void logRequest(JoinPoint joinPoint) {
+    protected void logController(JoinPoint joinPoint) {
+        logRequest(joinPoint);
+    }
+
+    private void logRequest(JoinPoint joinPoint) {
         HttpServletRequest request = getHttpServletRequest();
         String uri = request.getRequestURI();
         String httpMethod = request.getMethod();

--- a/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
@@ -9,13 +9,11 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Aspect
-@Component
 @Slf4j
 abstract class RequestLoggingAspect {
 

--- a/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.joining;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Parameter;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
@@ -15,6 +16,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Aspect
 @Component
+@Slf4j
 abstract class RequestLoggingAspect {
 
     @Pointcut("execution(* ddangkong.controller..*Controller.*(..))")
@@ -27,6 +29,16 @@ abstract class RequestLoggingAspect {
 
     @Pointcut("allController() && !polling()")
     public void allControllerWithoutPolling() {
+    }
+
+    protected void logRequest(JoinPoint joinPoint) {
+        HttpServletRequest request = getHttpServletRequest();
+        String uri = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String queryParameters = getQueryParameters(request);
+        String body = getBody(joinPoint);
+
+        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
     }
 
     protected HttpServletRequest getHttpServletRequest() {

--- a/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
@@ -4,10 +4,8 @@ import static java.util.stream.Collectors.joining;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Parameter;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
@@ -17,8 +15,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Aspect
 @Component
-@Slf4j
-public class RequestLoggingAspect {
+abstract class RequestLoggingAspect {
 
     @Pointcut("execution(* ddangkong.controller..*Controller.*(..))")
     public void allController() {
@@ -32,23 +29,12 @@ public class RequestLoggingAspect {
     public void allControllerWithoutPolling() {
     }
 
-    @Before("allController()")
-    public void logController(JoinPoint joinPoint) {
-        HttpServletRequest request = getHttpServletRequest();
-        String uri = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        String queryParameters = getQueryParameters(request);
-        String body = getBody(joinPoint);
-
-        log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
-    }
-
-    private HttpServletRequest getHttpServletRequest() {
+    protected HttpServletRequest getHttpServletRequest() {
         ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         return requestAttributes.getRequest();
     }
 
-    private String getQueryParameters(HttpServletRequest request) {
+    protected String getQueryParameters(HttpServletRequest request) {
         String queryParameters = request.getParameterMap()
                 .entrySet()
                 .stream()
@@ -61,7 +47,7 @@ public class RequestLoggingAspect {
         return queryParameters;
     }
 
-    private String getBody(JoinPoint joinPoint) {
+    protected String getBody(JoinPoint joinPoint) {
         MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         Parameter[] parameters = methodSignature.getMethod().getParameters();
         Object[] args = joinPoint.getArgs();

--- a/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/RequestLoggingAspect.java
@@ -41,12 +41,12 @@ abstract class RequestLoggingAspect {
         log.info("Request Logging: {} {} body - {} parameters - {}", httpMethod, uri, body, queryParameters);
     }
 
-    protected HttpServletRequest getHttpServletRequest() {
+    private HttpServletRequest getHttpServletRequest() {
         ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         return requestAttributes.getRequest();
     }
 
-    protected String getQueryParameters(HttpServletRequest request) {
+    private String getQueryParameters(HttpServletRequest request) {
         String queryParameters = request.getParameterMap()
                 .entrySet()
                 .stream()
@@ -59,7 +59,7 @@ abstract class RequestLoggingAspect {
         return queryParameters;
     }
 
-    protected String getBody(JoinPoint joinPoint) {
+    private String getBody(JoinPoint joinPoint) {
         MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         Parameter[] parameters = methodSignature.getMethod().getParameters();
         Object[] args = joinPoint.getArgs();


### PR DESCRIPTION
## Issue Number
#251

## As-Is
<!-- 문제 상황 정의 -->
폴링 로깅을 하는 이유는 디버깅인데 해당 로깅을 prod, dev 두 환경에서 모두 수행할 필요가 없다고 판단하여
이를 리팩토링 대상으로 정의하였다.
운영 전 디버깅을 위한 환경은 Dev 환경이며, 때문에 폴링API에 대한 로깅은 Dev 환경에서만 수행하도록 설정한다고 생각이 들었다.

## To-Be
<!-- 변경 사항 -->
RequestLoggingAspect를 공통로직이 담긴 Abstract 클래스로 배치하고
이를 상속한 `DevRequestLoggingAspect` , `ProdRequestLoggingAspect` 를 생성하였다.

이에 `@Profile` 애노테이션을 붙여 
- `DevRequestLoggingAspect` 에선 **local, dev** 환경은 Polling API 로깅을 수행하고
- `ProdRequestLoggingAspect` 에선 **prod** 환경은 Polling API 로깅을 수행하지 않도록 처리하였다.


이를 통해 두 환경에 대한 역할을 명확히 분리하고 Prod 환경에서는 운영에 더 중요한 로그에 집중할 수 있도록 구현하였다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="853" alt="스크린샷 2024-08-28 23 19 36" src="https://github.com/user-attachments/assets/ed76531c-ed4f-43aa-bfba-3df1ceb87554">

### local, dev 환경
<img width="1628" alt="image" src="https://github.com/user-attachments/assets/dd6fca1f-7d46-482f-81a4-56dc0ec6a00e">

- local, dev 환경은 Polling API인 `/api/balances/rooms/2/round-finished?round=1` 가 **로깅되는 것을 확인** 

### prod 환경

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/a5b8b9f3-4111-4ce3-90f6-4bb9ea5d6481">

- prod 환경은 Polling API인 `/api/balances/rooms/2/round-finished?round=1` 가 **로깅되지 않는 것을 확인** 

## (Optional) Additional Description
