### PR TITLE
[FEAT] 500 에러가 아닌 에러 핸들링하기

### DIFF
--- a/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
@@ -68,9 +68,17 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(ClientErrorCode.NO_RESOURCE_FOUND);
     }
 
-    @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class, HttpMediaTypeNotSupportedException.class})
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-    public ErrorResponse handleNotSupportedRequestException(Exception e) {
+    public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.warn(e.getMessage());
+
+        return new ErrorResponse(ClientErrorCode.NOT_SUPPORTED_REQUEST);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    public ErrorResponse handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
         log.warn(e.getMessage());
 
         return new ErrorResponse(ClientErrorCode.NOT_SUPPORTED_REQUEST);

--- a/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
@@ -5,8 +5,10 @@ import ddangkong.exception.ClientErrorCode;
 import ddangkong.exception.InternalServerException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -51,6 +53,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleClientAbortException(ClientAbortException e) {
+        log.warn(e.getMessage());
+
+        return new ErrorResponse(ClientErrorCode.ALREADY_DISCONNECTED);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNoResourceFoundException(NoResourceFoundException e) {
         log.warn(e.getMessage());
@@ -58,12 +68,12 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(ClientErrorCode.NO_RESOURCE_FOUND);
     }
 
-    @ExceptionHandler
+    @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class, HttpMediaTypeNotSupportedException.class})
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-    public ErrorResponse handleMethodNotAllowedException(HttpRequestMethodNotSupportedException e) {
+    public ErrorResponse handleNotSupportedRequestException(Exception e) {
         log.warn(e.getMessage());
 
-        return new ErrorResponse(ClientErrorCode.METHOD_NOT_SUPPORTED);
+        return new ErrorResponse(ClientErrorCode.NOT_SUPPORTED_REQUEST);
     }
 
     @ExceptionHandler

--- a/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ddangkong/controller/exception/GlobalExceptionHandler.java
@@ -73,7 +73,7 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         log.warn(e.getMessage());
 
-        return new ErrorResponse(ClientErrorCode.NOT_SUPPORTED_REQUEST);
+        return new ErrorResponse(ClientErrorCode.METHOD_NOT_SUPPORTED);
     }
 
     @ExceptionHandler
@@ -81,7 +81,7 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
         log.warn(e.getMessage());
 
-        return new ErrorResponse(ClientErrorCode.NOT_SUPPORTED_REQUEST);
+        return new ErrorResponse(ClientErrorCode.MEDIA_TYPE_NOT_SUPPORTED);
     }
 
     @ExceptionHandler

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -52,7 +52,8 @@ public enum ClientErrorCode {
     URL_PARAMETER_ERROR("입력이 잘못되었습니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH("입력한 값의 타입이 잘못되었습니다."),
     NO_RESOURCE_FOUND("요청한 리소스를 찾을 수 없습니다."),
-    NOT_SUPPORTED_REQUEST("허용되지 않은 요청입니다."),
+    METHOD_NOT_SUPPORTED("허용되지 않은 메서드입니다."),
+    MEDIA_TYPE_NOT_SUPPORTED("허용되지 않은 미디어 타입입니다."),
     ALREADY_DISCONNECTED("이미 클라이언트에서 요청이 종료되었습니다."),
     INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다. 관리자에게 문의하세요."),
     ;

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -52,7 +52,8 @@ public enum ClientErrorCode {
     URL_PARAMETER_ERROR("입력이 잘못되었습니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH("입력한 값의 타입이 잘못되었습니다."),
     NO_RESOURCE_FOUND("요청한 리소스를 찾을 수 없습니다."),
-    METHOD_NOT_SUPPORTED("허용되지 않은 메서드입니다."),
+    NOT_SUPPORTED_REQUEST("허용되지 않은 요청입니다."),
+    ALREADY_DISCONNECTED("이미 클라이언트에서 요청이 종료되었습니다."),
     INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다. 관리자에게 문의하세요."),
     ;
 


### PR DESCRIPTION
## Issue Number
Closed #265 

## As-Is
<!-- 문제 상황 정의 -->
- Client에서 요청이 잘못된 상황까지 Discord 알람이 온다.

## To-Be
<!-- 변경 사항 -->
- HttpMediaTypeNotSupportedException, ClientAbortException을 400번대 에러로 처리

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/09454f0d-d8a6-4a31-8ab3-8e7f5425e5c1)

## (Optional) Additional Description

9/12 기준 dev, prod에서 온 알람 (SQL 관련 에러 제외)

### `HttpMediaTypeNotSupportedException`
```text
org.springframework.web.HttpMediaTypeNotSupportedException: Content-Type 'text/plain;charset=UTF-8' is not supported
```

해당 요청의 Content-Type을 지원하지 않는 것이므로 405 Method Not Allowed를 반환함

### `ClientAbortException`
```text
org.apache.catalina.connector.ClientAbortException: java.io.IOException: Broken pipe
    at org.apache.catalina.connector.OutputBuffer.realWriteBytes(OutputBuffer.java:341)
    at org.apache.catalina.connector.OutputBuffer.flushByteBuffer(OutputBuffer.java:776)
    at org.apache.catalina.connector.OutputBuffer.append(OutputBuffer.java:673)
    at org.apache.catalina.connector.OutputBuffer.writeBytes(OutputBuffer.java:376)
    at org.apache.catalina.connector.OutputBuffer.write(OutputBuffer.java:354)
```

클라이언트가 서버와의 연결을 갑작스럽게 종료했을 때 발생하는 에러이다.
400 Bad Request를 반환하도록 함


#### `CannotAcquireLockException`
- SQL Lock 관련 문제라서 서버 에러가 맞음

#### `AsyncRequestNotUsableException`
- Spring Framework에서 비동기 요청 처리와 관련된 문제로 발생하는 예외입니다. 이 예외는 주로 Spring MVC에서 비동기 요청을 처리하려고 할 때, 클라이언트 요청이 비동기 방식으로 처리될 수 없는 경우에 발생한다.
- 500 서버 에러로 처리

