### PR TITLE
[FEAT] CI/CD 스크립트에 분산 prod 환경 (prod-a, prod-b) 설정 적용

### DIFF
--- a/.github/workflows/be-cd-prod-a.yml
+++ b/.github/workflows/be-cd-prod-a.yml
@@ -1,0 +1,44 @@
+name: BE CD for Prod
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ "main" ]
+    paths:
+      - backend/**
+
+jobs:
+  deploy:
+    timeout-minutes: 3
+    runs-on: [ self-hosted, linux, ARM64, prod-a ]
+
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setting prod-secret.yml
+        run: |
+          echo "${{ secrets.PROD_SECRET_YML }}" > ./src/main/resources/prod-secret.yml
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bootJar
+
+      - name: Stop existing Java Application
+        run: ps -ef | grep 'java -jar' | awk '{print $2}' | xargs sudo kill -15 || true
+
+      - name: Start Java Application
+        run: sudo nohup java -jar -Dspring.profiles.active=prod ./build/libs/ddangkong-0.0.1-SNAPSHOT.jar &

--- a/.github/workflows/be-cd-prod-a.yml
+++ b/.github/workflows/be-cd-prod-a.yml
@@ -1,4 +1,4 @@
-name: BE CD for Prod
+name: BE CD for Prod-A
 
 on:
   workflow_dispatch:

--- a/.github/workflows/be-cd-prod-b.yml
+++ b/.github/workflows/be-cd-prod-b.yml
@@ -1,4 +1,4 @@
-name: BE CD for Prod
+name: BE CD for Prod-B
 
 on:
   workflow_dispatch:

--- a/.github/workflows/be-cd-prod-b.yml
+++ b/.github/workflows/be-cd-prod-b.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     timeout-minutes: 3
-    runs-on: [ self-hosted, linux, ARM64, prod ]
+    runs-on: [ self-hosted, linux, ARM64, prod-b ]
 
     defaults:
       run:

--- a/.github/workflows/be-ci-prod.yml
+++ b/.github/workflows/be-ci-prod.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     timeout-minutes: 4
-    runs-on: [ self-hosted, linux, ARM64, dev ]
+    runs-on: [ self-hosted, linux, ARM64, prod-a ]
 
     defaults:
       run:


### PR DESCRIPTION
## Issue Number
#281 

## As-Is
<!-- 문제 상황 정의 -->
Multi AZ 설정을 통한 API 서버 다중화 작업으로 SPOF(Single Point Of Failure)을 제거하여 HA(High Availability) 보장을 수행한다.

## To-Be
<!-- 변경 사항 -->
- 각 EC2에 Github Self-hosted Runner 설치 및 CI/CD 스크립트 수정
- CI/CD 스크립트에 분산 prod 환경 (prod-a, prod-b) 설정 적용
- CI는 prod-a 환경에서 수행
  - (prod-b의 CD가 도는 동안 prod-a는 CI를 돌리느라 WAS가 닫히는 시간에 텀이 있기 때문에 DownTime이 짧아지는 효과가 있을 것으로 예상)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
