### PR TITLE
[FEAT] 첫 라운드에 게임 준비 시간 추가

### DIFF
--- a/backend/src/main/java/ddangkong/domain/room/balance/roomcontent/RoomContent.java
+++ b/backend/src/main/java/ddangkong/domain/room/balance/roomcontent/RoomContent.java
@@ -24,6 +24,9 @@ import lombok.NoArgsConstructor;
 public class RoomContent {
 
     private static final int DELAY_MSEC = 2_000; // TODO SEC로 변경
+    private static final int GAME_WAITING_MSEC = 3_000; // TODO SEC로 변경
+    private static final int FIRST_ROUND = 1;
+    private static final int MSEC = 1_000;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,7 +61,11 @@ public class RoomContent {
             throw new VoteDeadlineConfiguredException();
         }
 
-        int afterSec = (timeLimit + DELAY_MSEC) / 1_000;
+        int afterSec = (timeLimit + DELAY_MSEC) / MSEC;
+        if (round == FIRST_ROUND) {
+            afterSec += GAME_WAITING_MSEC / MSEC;
+        }
+
         voteDeadline = now.plusSeconds(afterSec);
     }
 

--- a/backend/src/main/java/ddangkong/domain/room/balance/roomcontent/RoomContent.java
+++ b/backend/src/main/java/ddangkong/domain/room/balance/roomcontent/RoomContent.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 public class RoomContent {
 
     private static final int DELAY_MSEC = 2_000; // TODO SEC로 변경
-    private static final int GAME_WAITING_MSEC = 3_000; // TODO SEC로 변경
+    private static final int GAME_START_WAITING_MSEC = 3_000; // TODO SEC로 변경
     private static final int FIRST_ROUND = 1;
     private static final int MSEC = 1_000;
 
@@ -63,7 +63,7 @@ public class RoomContent {
 
         int afterSec = (timeLimit + DELAY_MSEC) / MSEC;
         if (round == FIRST_ROUND) {
-            afterSec += GAME_WAITING_MSEC / MSEC;
+            afterSec += GAME_START_WAITING_MSEC / MSEC;
         }
 
         voteDeadline = now.plusSeconds(afterSec);


### PR DESCRIPTION
## Issue Number
close #302 

## As-Is
<!-- 문제 상황 정의 -->
- 게임이 시작되었을 때 게임 준비 시간 3초가 주어지는데 1 라운드 종료 시간에 게임 준비 시간을 추가해주지 않어 게임이 투표 종료 설정 시간 전에 끝남

## To-Be
<!-- 변경 사항 -->
- 게임이 시작되었을 때 게임 준비 시간 3초가 주어지는데 1 라운드 종료 시간에 게임 준비 시간을 추가해주어야함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/c51ab1a0-bfc5-4b1a-b833-cba5eb94f45b)
