### PR TITLE
[FEAT] 스크린 리더 공통 컴포넌트 생성 

### DIFF
--- a/frontend/src/components/common/a11yOnly/A11yOnly.styled.ts
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.styled.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+
+export const a11yOnlyContainer = css({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  border: 0,
+  clip: 'rect(0, 0, 0, 0)',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+});

--- a/frontend/src/components/common/a11yOnly/A11yOnly.styled.ts
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.styled.ts
@@ -1,13 +1,14 @@
 import { css } from '@emotion/react';
 
-export const a11yOnlyContainer = css({
-  position: 'absolute',
-  width: '1px',
-  height: '1px',
-  padding: 0,
-  margin: '-1px',
-  border: 0,
-  clip: 'rect(0, 0, 0, 0)',
-  overflow: 'hidden',
-  whiteSpace: 'nowrap',
-});
+export const a11yOnlyLayout = css`
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+`;

--- a/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
@@ -15,9 +15,7 @@ describe('A11yOnly 컴포넌트 테스트', () => {
   test('aria-label 속성이 적용된 텍스트가 스크린 리더로 읽히는지 확인한다.', () => {
     render(<AllyOnly aria-label={SCREEN_READER_TEXT}>안녕하세요.</AllyOnly>);
 
-    const screenReaderElement = screen.getByLabelText(
-      '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.',
-    );
+    const screenReaderElement = screen.getByLabelText(SCREEN_READER_TEXT);
 
     expect(screenReaderElement).toBeInTheDocument();
   });

--- a/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
@@ -13,7 +13,7 @@ describe('A11yOnly 컴포넌트 테스트', () => {
   });
 
   test('aria-label 속성이 적용된 텍스트가 스크린 리더로 읽히는지 확인한다.', () => {
-    render(<AllyOnly aria-label={SCREEN_READER_TEXT}>안녕하세요.</AllyOnly>);
+    render(<AllyOnly aria-label={SCREEN_READER_TEXT} />);
 
     const screenReaderElement = screen.getByLabelText(SCREEN_READER_TEXT);
 

--- a/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
@@ -23,14 +23,18 @@ describe('A11yOnly 컴포넌트 테스트', () => {
   });
 
   test('aria-live 속성이 적용된 실시간 업데이트 메시지가 스크린 리더에 의해 읽히는지 확인한다.', () => {
-    render(
-      <AllyOnly as="div" aria-live="polite">
-        {SCREEN_READER_TEXT}
-      </AllyOnly>,
-    );
+    render(<AllyOnly aria-live="polite">{SCREEN_READER_TEXT}</AllyOnly>);
 
     const liveUpdateMessage = screen.getByText(SCREEN_READER_TEXT);
 
     expect(liveUpdateMessage).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('as 속성을 사용하여 p 태그로 렌더링되는지 확인한다.', () => {
+    render(<AllyOnly as="p">{SCREEN_READER_TEXT}</AllyOnly>);
+
+    const screenReaderElement = screen.getByText(SCREEN_READER_TEXT);
+
+    expect(screenReaderElement.tagName.toLowerCase()).toBe('p');
   });
 });

--- a/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
@@ -3,22 +3,17 @@ import { render, screen } from '@testing-library/react';
 import AllyOnly from './A11yOnly';
 
 describe('A11yOnly 컴포넌트 테스트', () => {
+  const SCREEN_READER_TEXT = '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.';
   test('스크린 리더 전용 텍스트가 DOM에 존재하는지 확인한다.', () => {
-    render(<AllyOnly>화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.</AllyOnly>);
+    render(<AllyOnly>{SCREEN_READER_TEXT}</AllyOnly>);
 
-    const screenReaderElement = screen.getByText(
-      '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.',
-    );
+    const screenReaderElement = screen.getByText(SCREEN_READER_TEXT);
 
     expect(screenReaderElement).toBeInTheDocument();
   });
 
   test('aria-label 속성이 적용된 텍스트가 스크린 리더로 읽히는지 확인한다.', () => {
-    render(
-      <AllyOnly aria-label="화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.">
-        안녕하세요.
-      </AllyOnly>,
-    );
+    render(<AllyOnly aria-label={SCREEN_READER_TEXT}>안녕하세요.</AllyOnly>);
 
     const screenReaderElement = screen.getByLabelText(
       '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.',
@@ -30,11 +25,11 @@ describe('A11yOnly 컴포넌트 테스트', () => {
   test('aria-live 속성이 적용된 실시간 업데이트 메시지가 스크린 리더에 의해 읽히는지 확인한다.', () => {
     render(
       <AllyOnly as="div" aria-live="polite">
-        실시간 업데이트 메시지
+        {SCREEN_READER_TEXT}
       </AllyOnly>,
     );
 
-    const liveUpdateMessage = screen.getByText('실시간 업데이트 메시지');
+    const liveUpdateMessage = screen.getByText(SCREEN_READER_TEXT);
 
     expect(liveUpdateMessage).toHaveAttribute('aria-live', 'polite');
   });

--- a/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+import AllyOnly from './A11yOnly';
+
+describe('A11yOnly 컴포넌트 테스트', () => {
+  test('스크린 리더 전용 텍스트가 DOM에 존재하는지 확인한다.', () => {
+    render(<AllyOnly>화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.</AllyOnly>);
+
+    const screenReaderElement = screen.getByText(
+      '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.',
+    );
+
+    expect(screenReaderElement).toBeInTheDocument();
+  });
+
+  test('aria-label 속성이 적용된 텍스트가 스크린 리더로 읽히는지 확인한다.', () => {
+    render(
+      <AllyOnly aria-label="화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.">
+        안녕하세요.
+      </AllyOnly>,
+    );
+
+    const screenReaderElement = screen.getByLabelText(
+      '화면에 표시되지 않고 스크린 리더로 읽을 수 있습니다.',
+    );
+
+    expect(screenReaderElement).toBeInTheDocument();
+  });
+
+  test('aria-live 속성이 적용된 실시간 업데이트 메시지가 스크린 리더에 의해 읽히는지 확인한다.', () => {
+    render(
+      <AllyOnly as="div" aria-live="polite">
+        실시간 업데이트 메시지
+      </AllyOnly>,
+    );
+
+    const liveUpdateMessage = screen.getByText('실시간 업데이트 메시지');
+
+    expect(liveUpdateMessage).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -1,17 +1,25 @@
-import { ElementType, ComponentPropsWithoutRef } from 'react';
+import { ElementType, AriaRole, ReactNode } from 'react';
 
 import { a11yOnlyLayout } from './A11yOnly.styled';
 
 interface A11yOnlyProps<T extends ElementType = 'span'> {
+  children: ReactNode;
   as?: T;
+  role?: AriaRole;
 }
 
 const A11yOnly = <T extends ElementType = 'span'>({
+  children,
   as,
+  role = 'text',
   ...props
-}: A11yOnlyProps<T> & ComponentPropsWithoutRef<T>) => {
+}: A11yOnlyProps<T>) => {
   const Component = as || 'span';
-  return <Component {...props} css={a11yOnlyLayout} />;
+  return (
+    <Component css={a11yOnlyLayout} role={role} {...props}>
+      {children}
+    </Component>
+  );
 };
 
 export default A11yOnly;

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -10,12 +10,13 @@ interface A11yOnlyProps<T extends ElementType = 'span'> {
 const A11yOnly = <T extends ElementType = 'span'>({
   as,
   role = 'text',
+  children,
   ...props
 }: PropsWithChildren<A11yOnlyProps<T>>) => {
   const Component = as || 'span';
   return (
     <Component css={a11yOnlyLayout} role={role} {...props}>
-      {props.children}
+      {children}
     </Component>
   );
 };

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -1,6 +1,6 @@
 import { ElementType, ReactNode } from 'react';
 
-import { a11yOnlyContainer } from './A11yOnly.styled';
+import { a11yOnlyLayout } from './A11yOnly.styled';
 
 interface A11yOnlyProps<T extends ElementType = 'span'> {
   as?: T;
@@ -10,7 +10,7 @@ interface A11yOnlyProps<T extends ElementType = 'span'> {
 const A11yOnly = <T extends ElementType = 'span'>({ as, children, ...props }: A11yOnlyProps<T>) => {
   const Component = as || 'span';
   return (
-    <Component {...props} css={a11yOnlyContainer}>
+    <Component {...props} css={a11yOnlyLayout}>
       {children}
     </Component>
   );

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -1,0 +1,19 @@
+import { ElementType, ReactNode } from 'react';
+
+import { a11yOnlyContainer } from './A11yOnly.styled';
+
+interface A11yOnlyProps<T extends ElementType = 'span'> {
+  as?: T;
+  children: ReactNode;
+}
+
+const A11yOnly = <T extends ElementType = 'span'>({ as, children, ...props }: A11yOnlyProps<T>) => {
+  const Component = as || 'span';
+  return (
+    <Component {...props} css={a11yOnlyContainer}>
+      {children}
+    </Component>
+  );
+};
+
+export default A11yOnly;

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -1,19 +1,17 @@
-import { ElementType, ReactNode } from 'react';
+import { ElementType, ComponentPropsWithoutRef } from 'react';
 
 import { a11yOnlyLayout } from './A11yOnly.styled';
 
 interface A11yOnlyProps<T extends ElementType = 'span'> {
   as?: T;
-  children: ReactNode;
 }
 
-const A11yOnly = <T extends ElementType = 'span'>({ as, children, ...props }: A11yOnlyProps<T>) => {
+const A11yOnly = <T extends ElementType = 'span'>({
+  as,
+  ...props
+}: A11yOnlyProps<T> & ComponentPropsWithoutRef<T>) => {
   const Component = as || 'span';
-  return (
-    <Component {...props} css={a11yOnlyLayout}>
-      {children}
-    </Component>
-  );
+  return <Component {...props} css={a11yOnlyLayout} />;
 };
 
 export default A11yOnly;

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -1,23 +1,21 @@
-import { ElementType, AriaRole, ReactNode } from 'react';
+import { ElementType, AriaRole, PropsWithChildren } from 'react';
 
 import { a11yOnlyLayout } from './A11yOnly.styled';
 
 interface A11yOnlyProps<T extends ElementType = 'span'> {
-  children: ReactNode;
   as?: T;
   role?: AriaRole;
 }
 
 const A11yOnly = <T extends ElementType = 'span'>({
-  children,
   as,
   role = 'text',
   ...props
-}: A11yOnlyProps<T>) => {
+}: PropsWithChildren<A11yOnlyProps<T>>) => {
   const Component = as || 'span';
   return (
     <Component css={a11yOnlyLayout} role={role} {...props}>
-      {children}
+      {props.children}
     </Component>
   );
 };


### PR DESCRIPTION
## Issue Number
#319 

## As-Is
<!-- 문제 상황 정의 -->

![image](https://github.com/user-attachments/assets/fd4e0eb8-a431-4dad-b801-ddceebf343a1)

스크린 리더 접근성 개선 회의에서, 시각적으로 숨겨져 있고 스크린 리더에서만 읽혀야 하는 요소들을 개별적으로 div에 스타일을 적용하는 방식은 직관적이지만, 코드가 복잡해지면 어떤 태그가 스크린 리더 전용인지 식별하기 어려워질 수 있다는 문제가 제기되었다.

이로 인해 가독성과 유지보수성을 고려했을 때, 이러한 요소들을 한눈에 파악하고 관리할 수 있는 A11yOnly 컴포넌트를 도입하는 것이 바람직하다는 의견이 모아졌다. 해당 컴포넌트를 통해 스크린 리더 전용 요소를 명확하게 정의하고, 코드의 일관성을 높이기로 결정했다.

## To-Be
<!-- 변경 사항 -->
- [x] 화면에는 보이지 않고 스크린 리더에 읽히는 컴포넌트 생성
- [x] 화면에 보이지 않도록 스타일 추가
- [x] A11yOnly 컴포넌트 테스트 작성 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/83b439ba-f69e-4a32-8320-915f7a591919)

## (Optional) Additional Description
### ElementType = 'span'
타입 수준에서 기본값을 지정해주는 역할이며, `as` prop이 없을 때 기본적으로 span 타입으로 간주되도록 합니다. -> 컴파일 시 적용 !

### const Component = as || 'span'
컴포넌트를 렌더링할 때 `as`가 없는 경우 기본값인 'span' 태그로 렌더링 됩니다. -> 런타임 시 적용 !

### 사용 예시
라운드 결과 페이지에서 A11yOnly 컴포넌트를 적용한 예시를 보여드릴게요 👏

- 수정 전(리뷰 반영 전)

![image](https://github.com/user-attachments/assets/be27346c-999e-4495-80a0-20a450674529)

- 수정 후(리뷰 반영 후)
![image](https://github.com/user-attachments/assets/cd21d596-6d53-4f93-a988-94014e4b978f)


https://github.com/user-attachments/assets/ba17de0e-e3bd-44f5-9de8-e39aa9a0cbff


공통 컴포넌트를 만드는 것은 늘 고민이 많네요  .. 😎 혹시나 더 고려할 부분이나 궁금한 점은 없을까요 ?! 리뷰 남겨주시면 의논해서 반영해 볼게요 👏👏 


## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/