### PR TITLE
[FIX] application-dev.yml에는 dev-init.sql을 실행하지 않도록 수정

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -8,11 +8,6 @@ spring:
     username: ${secret.datasource.username}
     password: ${secret.datasource.password}
 
-  sql:
-    init:
-      mode: always
-      schema-locations: classpath:sql/data-dev.sql
-
   jpa:
     defer-datasource-initialization: true
     hibernate:


### PR DESCRIPTION
## Issue Number

#323 

## As-Is
<!-- 문제 상황 정의 -->

 - Dev 환경에서 dev-init.sql이 지워졌지만, application-dev.yml에는 dev-init.sql를 실행하도록 하여 오류가 남

## To-Be
<!-- 변경 사항 -->

- application-dev.yml의 설정에서 dev-init.sql를 실행 부분 제거

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

![image](https://github.com/user-attachments/assets/4d3c7b66-addb-4b87-b20f-0e023b15ebe9)


## (Optional) Additional Description
