### PR TITLE
[REFACTOR] 라운드 결과 페이지 스크린 리더 개선

### DIFF
--- a/frontend/src/components/NicknameItem/NicknameItem.tsx
+++ b/frontend/src/components/NicknameItem/NicknameItem.tsx
@@ -14,7 +14,7 @@ const NicknameItem = ({ nickName }: NicknameItemProp) => {
 
   return (
     <li css={nicknameItemLayout}>
-      <img src={SillyDdangkong} alt="사용자 프로필" css={profileImage} />
+      <img src={SillyDdangkong} alt="" css={profileImage} />
       <span css={nicknameText(isMyNickname)}>{nickName}</span>
     </li>
   );

--- a/frontend/src/components/OptionParticipants/OptionParticipants.tsx
+++ b/frontend/src/components/OptionParticipants/OptionParticipants.tsx
@@ -18,7 +18,7 @@ const OptionParticipants = ({ optionName, memberCount, members }: OptionParticip
       <A11yOnly>
         {optionName}.{memberCount}명
       </A11yOnly>
-      <p css={optionInfo} aria-hidden={true}>
+      <p css={optionInfo} aria-hidden>
         {optionName}: {memberCount}
       </p>
       <ul css={participantsListWrapper}>

--- a/frontend/src/components/OptionParticipants/OptionParticipants.tsx
+++ b/frontend/src/components/OptionParticipants/OptionParticipants.tsx
@@ -3,6 +3,7 @@ import {
   optionParticipantsLayout,
   participantsListWrapper,
 } from './OptionParticipants.styled';
+import A11yOnly from '../common/a11yOnly/A11yOnly';
 import NicknameItem from '../NicknameItem/NicknameItem';
 
 export interface OptionParticipantsProps {
@@ -14,7 +15,10 @@ export interface OptionParticipantsProps {
 const OptionParticipants = ({ optionName, memberCount, members }: OptionParticipantsProps) => {
   return (
     <div css={optionParticipantsLayout}>
-      <p css={optionInfo}>
+      <A11yOnly>
+        {optionName}.{memberCount}명
+      </A11yOnly>
+      <p css={optionInfo} aria-hidden={true}>
         {optionName}: {memberCount}
       </p>
       <ul css={participantsListWrapper}>

--- a/frontend/src/components/RoundResultTab/RoundResultTab.tsx
+++ b/frontend/src/components/RoundResultTab/RoundResultTab.tsx
@@ -15,7 +15,12 @@ const TAB_TITLE = {
 
 const RoundResultTab = ({ tab, activeTab, handleClickTab }: RoundResultTabProps) => {
   return (
-    <button css={tabButtonStyle(activeTab === tab)} onClick={() => handleClickTab(tab)}>
+    <button
+      css={tabButtonStyle(activeTab === tab)}
+      onClick={() => handleClickTab(tab)}
+      role="tab"
+      aria-current={activeTab === tab}
+    >
       {TAB_TITLE[tab]}
     </button>
   );

--- a/frontend/src/components/RoundVoteContainer/RoundVoteContainer.test.tsx
+++ b/frontend/src/components/RoundVoteContainer/RoundVoteContainer.test.tsx
@@ -3,6 +3,8 @@ import { userEvent } from '@testing-library/user-event';
 
 import RoundVoteContainer from './RoundVoteContainer';
 
+import ROUND_VOTE_RESULT from '@/mocks/data/roundVoteResult.json';
+
 import { customRender } from '@/test-utils';
 
 describe('RoundVoteContainer 컴포넌트 테스트', () => {
@@ -14,16 +16,23 @@ describe('RoundVoteContainer 컴포넌트 테스트', () => {
     await user.click(button);
 
     await waitFor(() => {
-      // 첫 번째 선택지의 투표자 확인
-      expect(screen.getByText('d')).toBeInTheDocument();
+      // 첫 번째 선택지의 투표 멤버 확인
+      const firstOptionMembers = ROUND_VOTE_RESULT.group.firstOption.members;
+      firstOptionMembers.forEach((member) => {
+        expect(screen.getByText(member)).toBeInTheDocument();
+      });
 
-      // 두 번째 선택지의 투표자들 확인
-      expect(screen.getByText('일이삼사오육칠팔구십일이')).toBeInTheDocument();
-      expect(screen.getByText('가나다라마바사아자차카타')).toBeInTheDocument();
-      expect(screen.getByText('abc')).toBeInTheDocument();
-      expect(screen.getByText('땅콩땅콩땅콩땅콩땅콩땅콩')).toBeInTheDocument();
-      expect(screen.getByText('123456789012')).toBeInTheDocument();
-      expect(screen.getByText('안녕하세요안녕하세요안녕')).toBeInTheDocument();
+      // 두 번째 선택지의 투표 멤버 확인
+      const secondOptionMembers = ROUND_VOTE_RESULT.group.secondOption.members;
+      secondOptionMembers.forEach((member) => {
+        expect(screen.getByText(member)).toBeInTheDocument();
+      });
+
+      // 투표를 하지 않은 멤버 확인
+      const giveUpMembers = ROUND_VOTE_RESULT.group.giveUp.members;
+      giveUpMembers.forEach((member) => {
+        expect(screen.getByText(member)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/components/RoundVoteContainer/RoundVoteContainer.test.tsx
+++ b/frontend/src/components/RoundVoteContainer/RoundVoteContainer.test.tsx
@@ -10,25 +10,20 @@ describe('RoundVoteContainer 컴포넌트 테스트', () => {
     const user = userEvent.setup();
     customRender(<RoundVoteContainer />);
 
-    const button = await screen.findByRole('button', { name: '투표 현황' });
+    const button = await screen.findByRole('tab', { name: '투표 현황' });
     await user.click(button);
 
     await waitFor(() => {
-      // 첫 번째 선택지와 투표자 확인
-      expect(screen.getByText((content) => content.includes('100억 빚 송강'))).toBeInTheDocument();
-      expect(screen.getByText((content) => content.includes('d'))).toBeInTheDocument();
-      // 두 번째 선택지와 투표자 확인
-      expect(
-        screen.getByText((content) => content.includes('100억 부자 송강호')),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText((content) => content.includes('일이삼사오육칠팔구십일이')),
-      ).toBeInTheDocument();
-      // 기권자 확인
-      expect(
-        screen.getByText((content) => content.includes('투표에 참여하지 않으셨어요')),
-      ).toBeInTheDocument();
-      expect(screen.getByText((content) => content.includes('ㅁ'))).toBeInTheDocument();
+      // 첫 번째 선택지의 투표자 확인
+      expect(screen.getByText('d')).toBeInTheDocument();
+
+      // 두 번째 선택지의 투표자들 확인
+      expect(screen.getByText('일이삼사오육칠팔구십일이')).toBeInTheDocument();
+      expect(screen.getByText('가나다라마바사아자차카타')).toBeInTheDocument();
+      expect(screen.getByText('abc')).toBeInTheDocument();
+      expect(screen.getByText('땅콩땅콩땅콩땅콩땅콩땅콩')).toBeInTheDocument();
+      expect(screen.getByText('123456789012')).toBeInTheDocument();
+      expect(screen.getByText('안녕하세요안녕하세요안녕')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/TabContentContainer/TabContentContainer.tsx
+++ b/frontend/src/components/TabContentContainer/TabContentContainer.tsx
@@ -86,6 +86,10 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
                 <span css={totalResultInfoText}>📢 전체 유저 사이에서는 의견이 반반이에요 😲</span>
               ) : (
                 <>
+                  <A11yOnly>
+                    📢 전체 유저 중 {dominantVoteData.dominantPercent}%는.
+                    {dominantVoteData.dominantName}를 선택했어요
+                  </A11yOnly>
                   <span css={totalResultInfoText} aria-hidden={true}>
                     📢 전체 유저 중{' '}
                     <span css={emphasizeText}>{dominantVoteData.dominantPercent}%</span>는
@@ -93,10 +97,6 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
                   <span css={totalResultInfoText} aria-hidden={true}>
                     <span css={emphasizeText}>{dominantVoteData.dominantName}</span>를 선택했어요 !
                   </span>
-                  <A11yOnly>
-                    📢 전체 유저 중 {dominantVoteData.dominantPercent}%는.
-                    {dominantVoteData.dominantName}를 선택했어요
-                  </A11yOnly>
                 </>
               )}
             </div>

--- a/frontend/src/components/TabContentContainer/TabContentContainer.tsx
+++ b/frontend/src/components/TabContentContainer/TabContentContainer.tsx
@@ -51,9 +51,9 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
 
   const dominantVoteData = totalResult ? getDominantVote(totalResult) : null;
 
-  const screenReaderFirstOption = `${groupRoundResult.firstOption.name},${groupRoundResult.firstOption.percent}%,${groupRoundResult.firstOption.memberCount}명 선택,`;
-  const screenReaderSecondOption = `${groupRoundResult.secondOption.name},${groupRoundResult.secondOption.percent}%,${groupRoundResult.secondOption.memberCount}명 선택`;
-  const screenReaderDominantVote = `📢 전체 유저 중 ${dominantVoteData?.dominantPercent}%는, ${dominantVoteData?.dominantName}를 선택했어요`;
+  const screenReaderFirstOption = `${groupRoundResult.firstOption.name} ${groupRoundResult.firstOption.percent}%. ${groupRoundResult.firstOption.memberCount}명 선택.`;
+  const screenReaderSecondOption = `${groupRoundResult.secondOption.name} ${groupRoundResult.secondOption.percent}%. ${groupRoundResult.secondOption.memberCount}명 선택`;
+  const screenReaderDominantVote = `📢 전체 유저 중 ${dominantVoteData?.dominantPercent}%는. ${dominantVoteData?.dominantName}를 선택했어요`;
 
   return (
     <div css={contentWrapperStyle}>

--- a/frontend/src/components/TabContentContainer/TabContentContainer.tsx
+++ b/frontend/src/components/TabContentContainer/TabContentContainer.tsx
@@ -51,16 +51,18 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
 
   const dominantVoteData = totalResult ? getDominantVote(totalResult) : null;
 
+  const screenReaderFirstOption = `${groupRoundResult.firstOption.name},${groupRoundResult.firstOption.percent}%,${groupRoundResult.firstOption.memberCount}명 선택,`;
+  const screenReaderSecondOption = `${groupRoundResult.secondOption.name},${groupRoundResult.secondOption.percent}%,${groupRoundResult.secondOption.memberCount}명 선택`;
+  const screenReaderDominantVote = `📢 전체 유저 중 ${dominantVoteData?.dominantPercent}%는, ${dominantVoteData?.dominantName}를 선택했어요`;
+
   return (
     <div css={contentWrapperStyle}>
       <TopicContainer />
       {isVote && isVoteStatisticsTabActive && (
         <>
           <A11yOnly>
-            {groupRoundResult.firstOption.name}.{groupRoundResult.firstOption.percent}%.
-            {groupRoundResult.firstOption.memberCount}명 선택. {groupRoundResult.secondOption.name}.
-            {groupRoundResult.secondOption.percent}%.{groupRoundResult.secondOption.memberCount}명
-            선택
+            {screenReaderFirstOption}
+            {screenReaderSecondOption}
           </A11yOnly>
           <div css={roundVoteResultContainer} aria-hidden>
             <div css={categoryContainer}>
@@ -86,10 +88,7 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
                 <span css={totalResultInfoText}>📢 전체 유저 사이에서는 의견이 반반이에요 😲</span>
               ) : (
                 <>
-                  <A11yOnly>
-                    📢 전체 유저 중 {dominantVoteData.dominantPercent}%는.
-                    {dominantVoteData.dominantName}를 선택했어요
-                  </A11yOnly>
+                  <A11yOnly>{screenReaderDominantVote}</A11yOnly>
                   <span css={totalResultInfoText} aria-hidden>
                     📢 전체 유저 중{' '}
                     <span css={emphasizeText}>{dominantVoteData.dominantPercent}%</span>는

--- a/frontend/src/components/TabContentContainer/TabContentContainer.tsx
+++ b/frontend/src/components/TabContentContainer/TabContentContainer.tsx
@@ -16,6 +16,7 @@ import {
   totalResultInfoText,
 } from './TabContentContainer.styled';
 import getDominantVote from './TabContentContainer.util';
+import A11yOnly from '../common/a11yOnly/A11yOnly';
 import OptionParticipantsContainer from '../OptionParticipantsContainer/OptionParticipantsContainer';
 import useTotalCountAnimation from '../RoundVoteContainer/RoundVoteContainer.hook';
 import TopicContainer from '../TopicContainer/TopicContainer';
@@ -55,7 +56,13 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
       <TopicContainer />
       {isVote && isVoteStatisticsTabActive && (
         <>
-          <div css={roundVoteResultContainer}>
+          <A11yOnly>
+            {groupRoundResult.firstOption.name}.{groupRoundResult.firstOption.percent}%.
+            {groupRoundResult.firstOption.memberCount}명 선택. {groupRoundResult.secondOption.name}.
+            {groupRoundResult.secondOption.percent}%.{groupRoundResult.secondOption.memberCount}명
+            선택
+          </A11yOnly>
+          <div css={roundVoteResultContainer} aria-hidden={true}>
             <div css={categoryContainer}>
               <span>{groupRoundResult.firstOption.name}</span>
               <span>{groupRoundResult.secondOption.name}</span>
@@ -76,18 +83,20 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
           {totalResult && dominantVoteData && (
             <div css={totalResultInfoContainer}>
               {dominantVoteData.isEqual ? (
-                <span css={totalResultInfoText}>
-                  🥜 땅콩 유저들 사이에서 선택이 팽팽하게 갈렸어요! 😲
-                </span>
+                <span css={totalResultInfoText}>📢 전체 유저 사이에서는 의견이 반반이에요 😲</span>
               ) : (
                 <>
-                  <span css={totalResultInfoText}>
-                    🥜 땅콩 유저 중{' '}
+                  <span css={totalResultInfoText} aria-hidden={true}>
+                    📢 전체 유저 중{' '}
                     <span css={emphasizeText}>{dominantVoteData.dominantPercent}%</span>는
                   </span>
-                  <span css={totalResultInfoText}>
+                  <span css={totalResultInfoText} aria-hidden={true}>
                     <span css={emphasizeText}>{dominantVoteData.dominantName}</span>를 선택했어요 !
                   </span>
+                  <A11yOnly>
+                    📢 전체 유저 중 {dominantVoteData.dominantPercent}%는.
+                    {dominantVoteData.dominantName}를 선택했어요
+                  </A11yOnly>
                 </>
               )}
             </div>

--- a/frontend/src/components/TabContentContainer/TabContentContainer.tsx
+++ b/frontend/src/components/TabContentContainer/TabContentContainer.tsx
@@ -62,7 +62,7 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
             {groupRoundResult.secondOption.percent}%.{groupRoundResult.secondOption.memberCount}명
             선택
           </A11yOnly>
-          <div css={roundVoteResultContainer} aria-hidden={true}>
+          <div css={roundVoteResultContainer} aria-hidden>
             <div css={categoryContainer}>
               <span>{groupRoundResult.firstOption.name}</span>
               <span>{groupRoundResult.secondOption.name}</span>
@@ -90,11 +90,11 @@ const TabContentContainer = ({ isVoteStatisticsTabActive }: TabContentContainerP
                     📢 전체 유저 중 {dominantVoteData.dominantPercent}%는.
                     {dominantVoteData.dominantName}를 선택했어요
                   </A11yOnly>
-                  <span css={totalResultInfoText} aria-hidden={true}>
+                  <span css={totalResultInfoText} aria-hidden>
                     📢 전체 유저 중{' '}
                     <span css={emphasizeText}>{dominantVoteData.dominantPercent}%</span>는
                   </span>
-                  <span css={totalResultInfoText} aria-hidden={true}>
+                  <span css={totalResultInfoText} aria-hidden>
                     <span css={emphasizeText}>{dominantVoteData.dominantName}</span>를 선택했어요 !
                   </span>
                 </>

--- a/frontend/src/components/layout/Header/Header.stories.tsx
+++ b/frontend/src/components/layout/Header/Header.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryObj, Meta } from '@storybook/react';
 
-import Header, { BackHeader, RoomSettingHeader, RoundHeader, TitleHeader } from './Header';
+import Header, { BackHeader, RoomSettingHeader, RoundResultHeader, TitleHeader } from './Header';
 
 const meta = {
   title: 'Header',
@@ -20,7 +20,7 @@ export const 방_설정_헤더: Story = {
 };
 
 export const 라운드_헤더: Story = {
-  render: () => <RoundHeader />,
+  render: () => <RoundResultHeader />,
 };
 
 export const 투표_현황_헤더: Story = {

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -95,6 +95,10 @@ export const RoundHeader = () => {
 
   return (
     <header css={headerLayout()}>
+      <A11yOnly>
+        {balanceContent.totalRound}라운드.중.{balanceContent.currentRound}라운드.{title}페이지
+      </A11yOnly>
+
       <span css={roundText} aria-hidden={true}>
         {balanceContent.currentRound}/{balanceContent.totalRound}
       </span>
@@ -102,10 +106,6 @@ export const RoundHeader = () => {
         {title}
       </h1>
       <span css={roundText} aria-hidden={true}></span>
-
-      <A11yOnly>
-        {balanceContent.totalRound}라운드.중.{balanceContent.currentRound}라운드.{title}페이지
-      </A11yOnly>
     </header>
   );
 };

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -18,6 +18,7 @@ import useRoutePath from './hooks/useRoutePath';
 import ArrowLeft from '@/assets/images/arrowLeft.svg';
 import ExitIcon from '@/assets/images/exitIcon.webp';
 import SettingIcon from '@/assets/images/settingsIcon.webp';
+import A11yOnly from '@/components/common/a11yOnly/A11yOnly';
 import RoomSettingModal from '@/components/common/RoomSettingModal/RoomSettingModal';
 import { ROUTES } from '@/constants/routes';
 import useBalanceContentQuery from '@/hooks/useBalanceContentQuery';
@@ -94,11 +95,17 @@ export const RoundHeader = () => {
 
   return (
     <header css={headerLayout()}>
-      <span css={roundText}>
+      <span css={roundText} aria-hidden={true}>
         {balanceContent.currentRound}/{balanceContent.totalRound}
       </span>
-      <h1 css={gameTitle}>{title}</h1>
-      <span css={roundText}></span>
+      <h1 css={gameTitle} aria-hidden={true}>
+        {title}
+      </h1>
+      <span css={roundText} aria-hidden={true}></span>
+
+      <A11yOnly>
+        {balanceContent.totalRound}라운드.중.{balanceContent.currentRound}라운드.{title}페이지
+      </A11yOnly>
     </header>
   );
 };

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -99,13 +99,13 @@ export const RoundHeader = () => {
         {balanceContent.totalRound}라운드.중.{balanceContent.currentRound}라운드.{title}페이지
       </A11yOnly>
 
-      <span css={roundText} aria-hidden={true}>
+      <span css={roundText} aria-hidden>
         {balanceContent.currentRound}/{balanceContent.totalRound}
       </span>
-      <h1 css={gameTitle} aria-hidden={true}>
+      <h1 css={gameTitle} aria-hidden>
         {title}
       </h1>
-      <span css={roundText} aria-hidden={true}></span>
+      <span css={roundText} aria-hidden></span>
     </header>
   );
 };

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -36,7 +36,7 @@ const Header = () => {
 
   if (isNicknamePage) return <TitleHeader title="닉네임 설정" />;
   if (isReadyPage) return <RoomSettingHeader title="밸런스 게임" />;
-  if (isRoundResultPage) return <RoundHeader />;
+  if (isRoundResultPage) return <RoundResultHeader />;
   if (isMatchingResultPage) return <MatchingResultHeader title="매칭 결과" />;
 };
 
@@ -85,25 +85,19 @@ export const RoomSettingHeader = ({ title }: HeaderProps) => {
 };
 
 // 4. 좌측 상단 라운드, 가운데 제목 차지하는 헤더 (API 호출 O) : 게임 화면, 라운드 통계 화면
-export const RoundHeader = () => {
+export const RoundResultHeader = () => {
   const { roomId } = useParams();
-  const isRoundResultPage = location.pathname === ROUTES.roundResult(Number(roomId));
-
   const { balanceContent } = useBalanceContentQuery(Number(roomId));
-
-  const title = isRoundResultPage ? '투표 결과' : '밸런스 게임';
+  const screenReaderRoundResult = `${balanceContent.totalRound}라운드 중. ${balanceContent.currentRound}라운드. 투표 결과 페이지`;
 
   return (
     <header css={headerLayout()}>
-      <A11yOnly>
-        {balanceContent.totalRound}라운드.중.{balanceContent.currentRound}라운드.{title}페이지
-      </A11yOnly>
-
+      <A11yOnly>{screenReaderRoundResult}</A11yOnly>
       <span css={roundText} aria-hidden>
         {balanceContent.currentRound}/{balanceContent.totalRound}
       </span>
       <h1 css={gameTitle} aria-hidden>
-        {title}
+        투표 결과
       </h1>
       <span css={roundText} aria-hidden></span>
     </header>

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -1,12 +1,12 @@
 import Content from '@/components/layout/Content/Content';
-import { RoundHeader } from '@/components/layout/Header/Header';
+import { RoundResultHeader } from '@/components/layout/Header/Header';
 import SelectContainer from '@/components/SelectContainer/SelectContainer';
 import TopicContainer from '@/components/TopicContainer/TopicContainer';
 
 const GamePage = () => {
   return (
     <>
-      <RoundHeader />
+      <RoundResultHeader />
       <Content>
         <TopicContainer />
         <SelectContainer />


### PR DESCRIPTION
## Issue Number
#325 

## As-Is
<!-- 문제 상황 정의 -->
### 투표 통계 탭

- 개선 전

https://github.com/user-attachments/assets/0334c3e8-72e6-49d0-91d4-e9812f06b6f0

```
📢
2 배너 랜드미크 
슬래시
5
투표 결과 머리말 레벨 1 앤드 배너
투표 통계 버튼 앤드 탐색 랜드마크
투표 현황 버튼 앤드 탐색
지금 20억 한꺼번에 받기 vs 죽을 때까지 매달 1000만원 받기
지금 20억 한꺼번에 받기
죽을 때까지 매달 1000만원 받기
100
%
0
%
2
명
0
명
땅콩 땅콩 유저 중
100
%
는
죽을 때까지 매달 1000만원 받기
를 선택했어요!
방장이 진행해 주세요 흐리게 표시 됨 버튼
```
- 문제점
1. 헤더의 정보를 끊어서 읽는다. 
2. 투표 통계와 투표 현황을 버튼으로 읽기 때문에 탭임을 인지하지 못한다.
3. 투표 통계를 끊어서 읽는다. 
4. 전체 땅콩 유저 투표 통계 요약을 끊어서 읽는다.

### 투표 현황 탭

https://github.com/user-attachments/assets/b1093121-bfed-448d-9bc7-ad5cb768e8d6

```
📢
투표 현황 버튼 앤드 탐색
지금 20억 한꺼번에 받기 vs 죽을 때까지 매달 1000만원 받기
지금 20억 한꺼번에 받기 
콜론
2
사용자 이미지
엉뚱한 염소
사용자 이미지
웃긴 참새
죽을 때까지 매달 1000만원 받기
콜론
0
명
투표에 참여하지 않으셨어요
콜론
0
명
```
- 문제점
1. 선택지와 투표 인원 정보를 끊어서 읽고, 불필요한 텍스트까지 읽는다.

## To-Be
<!-- 변경 사항 -->
- [x] 투표 통계, 투표 현황 탭인지 인식할 수 있도록 role="tab"으로 수정
- [x] 투표 통계, 투표 현황에서 현재 어떤 탭에 위치하고 있는지 알 수 있도록 aria-current 적용
- [x] 라운드 결과 헤더에 현재 라운드 및 페이지 이름을 알려주기 위해 헤더 시각적 요소에 aria-hidden 처리 및 A11yOnly 컴포넌트를 활용하여 접근성 전용 텍스트 추가
- [x] 투표 통계 탭 내용에서 끊어 읽는 문제를 해결하기 위해서 시각적 요소에 aria-hidden 처리 및 A11yOnly 컴포넌트를 활용하여 접근성 전용 텍스트 추가
- [x] 전체 유저의 결과를 요약해서 보여주는 텍스트 수정
- [x] 투표 현황 탭 내용에서 끊어 읽고, 불 필요한 콜론을 읽는 문제를 해결하기 위해 옵션과 투표 수의 시각적 요소를 aria-hidden 처리를 하고 A11yOnly 컴포넌트를 활용하여 접근성 전용 텍스트 추가


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
### 투표 통계 탭

- 개선 후

https://github.com/user-attachments/assets/b24a5108-2af6-49d6-973e-4fcced7a387a

```
📢
5라운드 중 1라운드 투표 결과 페이지 배너 랜드마크
투표 통계 현재 항목 탭 탐색 랜드마크 총 두 개 중 1번째
투표 현황 탭 탐색 총 두 개 중 2번째
당신의 결혼 상대는?
100억 빚 송강 73% 1명 선택 100억 부자 송강호 27% 10명 선택
공지용 확성기 전체 유저 중 84%는 100억 부자 송강호를 선택했어요
```

### 투표 현황 탭

- 개선 후

https://github.com/user-attachments/assets/b3424263-e51c-42b6-a0cf-ce229da007c5

```
📢
투표 현황 현재 항목 탭 앤드 탐색 총 두 개 중 2번
당신의 결혼 상대는?
100억 빚 송강 1명
사용자 프로필 이미지
d
100억 부자 송강호 10명
사용자 프로필 이미지
일이삼사오육칠팔구십일이
사용자 프로필 이미지
가나다라마바사아자차카
```


처음에는 aria-label과 role='text'와 A11yOnly 컴포넌트 이용 중 어떻게 적절하게 사용할지 고민이 되었습니다.

그 중에서 A11yOnly을 많이 활용하여 개선한 가장 큰 이유는 `기존의 시각적 요소 코드는 놔두고, 접근성을 위한 콘텐츠를 명시적으로 추가하여 코드를 관리하고 파악하기 용이`하다고 생각했기 때문입니다 🌞
또한 role="text"는 mdn의 aria 속성에서 찾을 수 없었고, 접근성 개선을 위해 role="text"를 사용하는 것에 대해 신중해야 한다는 아티클을 보아서 공유합니다 .. 🥹 !!

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
https://www.boia.org/blog/should-your-site-use-the-text-role-for-accessibility

추가로 개선되어야 하거나 회의가 필요한 부분 얼마든지 환영합니다 파이탱탱탱 🌟👏


## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/