### PR TITLE
[FEAT] 방 게임 진행 시간 변경

### DIFF
--- a/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
@@ -22,7 +22,7 @@ public class RoomSetting {
     private static final int DEFAULT_TOTAL_ROUND = 5;
     private static final int MIN_TOTAL_ROUND = 3;
     private static final int MAX_TOTAL_ROUND = 10;
-    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(5_000, 10_000, 15_000);
+    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(5_000, 10_000, 15_000, 30_000);
     private static final int DEFAULT_TIME_LIMIT_MSEC = 10_000;
 
     @Column(nullable = false)

--- a/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
@@ -22,7 +22,7 @@ public class RoomSetting {
     private static final int DEFAULT_TOTAL_ROUND = 5;
     private static final int MIN_TOTAL_ROUND = 3;
     private static final int MAX_TOTAL_ROUND = 10;
-    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(5_000, 10_000, 15_000, 30_000);
+    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(10_000, 15_000, 30_000, 60_000);
     private static final int DEFAULT_TIME_LIMIT_MSEC = 10_000;
 
     @Column(nullable = false)

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -24,7 +24,7 @@ public enum ClientErrorCode {
 
     // RoomSetting
     // todo s로 변경
-    INVALID_TIME_LIMIT("시간 제한은 %dms / %dms / %dms 만 가능합니다. requested timeLimit: %d"),
+    INVALID_TIME_LIMIT("시간 제한은 %s 만 가능합니다. requested timeLimit: %d"),
     INVALID_RANGE_TOTAL_ROUND("총 라운드는 %d 이상, %d 이하만 가능합니다. requested totalRound: %d"),
 
     // Member

--- a/backend/src/main/java/ddangkong/exception/room/InvalidTimeLimitException.java
+++ b/backend/src/main/java/ddangkong/exception/room/InvalidTimeLimitException.java
@@ -9,8 +9,7 @@ public class InvalidTimeLimitException extends BadRequestException {
 
     public InvalidTimeLimitException(List<Integer> allowedTimeLimits, int requestedTimeLimit) {
         super(INVALID_TIME_LIMIT.getMessage()
-                .formatted(allowedTimeLimits.get(0), allowedTimeLimits.get(1), allowedTimeLimits.get(2),
-                        requestedTimeLimit));
+                .formatted(allowedTimeLimits.toString(), requestedTimeLimit));
     }
 
     @Override

--- a/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
@@ -174,7 +174,7 @@ class RoomBalanceVoteControllerTest extends BaseControllerTest {
                     "투표_매칭도_조회",
                     3,
                     RoomStatus.FINISH,
-                    new RoomSetting(3, 5000, Category.IF)));
+                    new RoomSetting(3, 15_000, Category.IF)));
 
             BalanceContent balanceContent1 = balanceContentRepository.save(new BalanceContent(Category.IF, "if1"));
             balanceOptionRepository.save(new BalanceOption("option1", balanceContent1));

--- a/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class RoomSettingTest {
 
-    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(5_000, 10_000, 15_000, 30_000);
+    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(10_000, 15_000, 30_000, 60_000);
 
     @Nested
     class 방_설정 {
@@ -23,7 +23,7 @@ class RoomSettingTest {
         @ValueSource(ints = {3, 10})
         void 라운드는_3이상_10이하_여야한다(int validTotalRound) {
             // when & then
-            assertThatCode(() -> new RoomSetting(validTotalRound, 5000, Category.IF))
+            assertThatCode(() -> new RoomSetting(validTotalRound, 15_000, Category.IF))
                     .doesNotThrowAnyException();
         }
 
@@ -31,14 +31,14 @@ class RoomSettingTest {
         @ValueSource(ints = {2, 11})
         void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
             // when & then
-            assertThatThrownBy(() -> new RoomSetting(notValidTotalRound, 5000, Category.IF))
+            assertThatThrownBy(() -> new RoomSetting(notValidTotalRound, 15_000, Category.IF))
                     .isExactlyInstanceOf(InvalidRangeTotalRoundException.class)
                     .hasMessage("총 라운드는 %d 이상, %d 이하만 가능합니다. requested totalRound: %d"
                             .formatted(3, 10, notValidTotalRound));
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {5_000, 10_000, 15_000, 30_000})
+        @ValueSource(ints = {10_000, 15_000, 30_000, 60_000})
         void 시간_제한은_허용된_시간_중_하나_여야한다(int validateTimeLimit) {
             // when & then
             assertThatCode(() -> new RoomSetting(5, validateTimeLimit, Category.IF))
@@ -46,7 +46,7 @@ class RoomSettingTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {4_999, 10_001, 15_001, 30_001})
+        @ValueSource(ints = {10_001, 15_001, 30_001, 59_999})
         void 시간_제한은_특정_시간이_아니라면_예외를_던진다(int notValidTimeLimit) {
             // when & then
             assertThatThrownBy(() -> new RoomSetting(5, notValidTimeLimit, Category.IF))
@@ -63,7 +63,7 @@ class RoomSettingTest {
         @ValueSource(ints = {3, 10})
         void 라운드는_3이상_10이하_여야한다(int totalRound) {
             // given
-            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+            RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
             // when
             setting.updateTotalRound(totalRound);
@@ -76,7 +76,7 @@ class RoomSettingTest {
         @ValueSource(ints = {2, 11})
         void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
             // given
-            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+            RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
             // when & then
             assertThatThrownBy(() -> setting.updateTotalRound(notValidTotalRound))
@@ -89,10 +89,10 @@ class RoomSettingTest {
     @Nested
     class 제한_시간_설정 {
         @ParameterizedTest
-        @ValueSource(ints = {5_000, 10_000, 15_000, 30_000})
+        @ValueSource(ints = {10_000, 15_000, 30_000, 60_000})
         void 시간_제한은_허용된_시간_중_하나_여야한다(int timeLimit) {
             // given
-            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+            RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
             // when
             setting.updateTimeLimit(timeLimit);
@@ -102,10 +102,10 @@ class RoomSettingTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {4_999, 10_001, 15_001, 30_001})
+        @ValueSource(ints = {9_999, 15_001, 30_001, 59_999})
         void 시간_제한은_특정_시간이_아니라면_예외를_던진다(int notValidTimeLimit) {
             // given
-            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+            RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
             // when & then
             assertThatThrownBy(() -> setting.updateTimeLimit(notValidTimeLimit))

--- a/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
@@ -21,7 +21,7 @@ class RoomSettingTest {
 
         @ParameterizedTest
         @ValueSource(ints = {3, 10})
-        void 라운드는_3이상_10이하_여야한다(int validTotalRound) {
+        void 라운드는_특정_범위_내_있어야_한다(int validTotalRound) {
             // when & then
             assertThatCode(() -> new RoomSetting(validTotalRound, 15_000, Category.IF))
                     .doesNotThrowAnyException();
@@ -29,7 +29,7 @@ class RoomSettingTest {
 
         @ParameterizedTest
         @ValueSource(ints = {2, 11})
-        void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
+        void 라운드_수가_범위를_벗어나는_경우_예외를_던진다(int notValidTotalRound) {
             // when & then
             assertThatThrownBy(() -> new RoomSetting(notValidTotalRound, 15_000, Category.IF))
                     .isExactlyInstanceOf(InvalidRangeTotalRoundException.class)
@@ -61,7 +61,7 @@ class RoomSettingTest {
 
         @ParameterizedTest
         @ValueSource(ints = {3, 10})
-        void 라운드는_3이상_10이하_여야한다(int totalRound) {
+        void 라운드는_특정_범위_내_있어야_한다(int totalRound) {
             // given
             RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
@@ -74,7 +74,7 @@ class RoomSettingTest {
 
         @ParameterizedTest
         @ValueSource(ints = {2, 11})
-        void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
+        void 라운드_수가_범위를_벗어나는_경우_예외를_던진다(int notValidTotalRound) {
             // given
             RoomSetting setting = new RoomSetting(5, 15_000, Category.IF);
 
@@ -88,6 +88,7 @@ class RoomSettingTest {
 
     @Nested
     class 제한_시간_설정 {
+
         @ParameterizedTest
         @ValueSource(ints = {10_000, 15_000, 30_000, 60_000})
         void 시간_제한은_허용된_시간_중_하나_여야한다(int timeLimit) {

--- a/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/RoomSettingTest.java
@@ -1,20 +1,35 @@
 package ddangkong.domain.room;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ddangkong.domain.balance.content.Category;
 import ddangkong.exception.room.InvalidRangeTotalRoundException;
 import ddangkong.exception.room.InvalidTimeLimitException;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class RoomSettingTest {
+
+    private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(5_000, 10_000, 15_000, 30_000);
+
     @Nested
-    class 방_설정_변경 {
+    class 방_설정 {
+
+        @ParameterizedTest
+        @ValueSource(ints = {3, 10})
+        void 라운드는_3이상_10이하_여야한다(int validTotalRound) {
+            // when & then
+            assertThatCode(() -> new RoomSetting(validTotalRound, 5000, Category.IF))
+                    .doesNotThrowAnyException();
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {2, 11})
-        void 라운드는_3이상_10이하_여야한다(int notValidTotalRound) {
+        void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
             // when & then
             assertThatThrownBy(() -> new RoomSetting(notValidTotalRound, 5000, Category.IF))
                     .isExactlyInstanceOf(InvalidRangeTotalRoundException.class)
@@ -23,13 +38,80 @@ class RoomSettingTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {5001, 10001, 15001})
-        void 시간_제한은_5000_10000_15000중_하나_여야한다(int notValidTimeLimit) {
+        @ValueSource(ints = {5_000, 10_000, 15_000, 30_000})
+        void 시간_제한은_허용된_시간_중_하나_여야한다(int validateTimeLimit) {
+            // when & then
+            assertThatCode(() -> new RoomSetting(5, validateTimeLimit, Category.IF))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {4_999, 10_001, 15_001, 30_001})
+        void 시간_제한은_특정_시간이_아니라면_예외를_던진다(int notValidTimeLimit) {
             // when & then
             assertThatThrownBy(() -> new RoomSetting(5, notValidTimeLimit, Category.IF))
                     .isExactlyInstanceOf(InvalidTimeLimitException.class)
-                    .hasMessage("시간 제한은 %dms / %dms / %dms 만 가능합니다. requested timeLimit: %d"
-                            .formatted(5000, 10000, 15000, notValidTimeLimit));
+                    .hasMessage("시간 제한은 %s 만 가능합니다. requested timeLimit: %d"
+                            .formatted(ALLOWED_TIME_LIMIT.toString(), notValidTimeLimit));
+        }
+    }
+
+    @Nested
+    class 방_라운드_변경 {
+
+        @ParameterizedTest
+        @ValueSource(ints = {3, 10})
+        void 라운드는_3이상_10이하_여야한다(int totalRound) {
+            // given
+            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+
+            // when
+            setting.updateTotalRound(totalRound);
+
+            // then
+            assertThat(setting.getTotalRound()).isEqualTo(totalRound);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {2, 11})
+        void 라운드는_3미만_10초과인_경우_예외를_던진다(int notValidTotalRound) {
+            // given
+            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+
+            // when & then
+            assertThatThrownBy(() -> setting.updateTotalRound(notValidTotalRound))
+                    .isExactlyInstanceOf(InvalidRangeTotalRoundException.class)
+                    .hasMessage("총 라운드는 %d 이상, %d 이하만 가능합니다. requested totalRound: %d"
+                            .formatted(3, 10, notValidTotalRound));
+        }
+    }
+
+    @Nested
+    class 제한_시간_설정 {
+        @ParameterizedTest
+        @ValueSource(ints = {5_000, 10_000, 15_000, 30_000})
+        void 시간_제한은_허용된_시간_중_하나_여야한다(int timeLimit) {
+            // given
+            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+
+            // when
+            setting.updateTimeLimit(timeLimit);
+
+            // then
+            assertThat(setting.getTimeLimit()).isEqualTo(timeLimit);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {4_999, 10_001, 15_001, 30_001})
+        void 시간_제한은_특정_시간이_아니라면_예외를_던진다(int notValidTimeLimit) {
+            // given
+            RoomSetting setting = new RoomSetting(5, 5_000, Category.IF);
+
+            // when & then
+            assertThatThrownBy(() -> setting.updateTimeLimit(notValidTimeLimit))
+                    .isExactlyInstanceOf(InvalidTimeLimitException.class)
+                    .hasMessage("시간 제한은 %s 만 가능합니다. requested timeLimit: %d"
+                            .formatted(ALLOWED_TIME_LIMIT.toString(), notValidTimeLimit));
         }
     }
 }

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -428,7 +428,7 @@ class RoomFacadeTest extends BaseServiceTest {
 
         private static final RoomStatus STATUS = RoomStatus.FINISH;
 
-        private static final RoomSetting ROOM_SETTING = new RoomSetting(5, 5000, Category.IF);
+        private static final RoomSetting ROOM_SETTING = new RoomSetting(5, 15_000, Category.IF);
 
         private BalanceContent content;
 

--- a/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
@@ -272,7 +272,7 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
                     "투표_매칭도_조회",
                     3,
                     RoomStatus.FINISH,
-                    new RoomSetting(3, 5000, Category.IF)));
+                    new RoomSetting(3, 15_000, Category.IF)));
 
             BalanceContent balanceContent1 = balanceContentRepository.save(new BalanceContent(Category.IF, "if1"));
             balanceOptionRepository.save(new BalanceOption("option1", balanceContent1));


### PR DESCRIPTION
## Issue Number
Closed #331 

## As-Is
<!-- 문제 상황 정의 -->

- 프론트 행님들이 스크린 리더 개선하는데 15초는 플레이 타임이 짧음
- 30초, 60초 설정 추가 필요

## To-Be
<!-- 변경 사항 -->

- 방의 게임 시간 설정을 10 15 30 60로 변경
- RoomSetting 관련 테스트 일부 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/f982bccb-4cbe-4077-942a-5cf33b4127f2)

## (Optional) Additional Description
