### PR TITLE
[REFACTOR] 방 설정 모달 접근성 개선 및 제한 시간 추가 반영

### DIFF
--- a/frontend/src/components/RoomSetting/RoomSetting.tsx
+++ b/frontend/src/components/RoomSetting/RoomSetting.tsx
@@ -22,7 +22,7 @@ const RoomSetting = () => {
         방 정보.
         카테고리 ${roomSetting.category.label}. 
         라운드 ${roomSetting.totalRound}. 
-        타이머 ${roomSetting.timeLimit / 1000}초.`;
+        제한시간 ${roomSetting.timeLimit / 1000}초.`;
 
   const handleClickCategory = () => {
     show(RoomSettingModal);
@@ -45,7 +45,7 @@ const RoomSetting = () => {
           <h2 css={bigTitle}>{roomSetting.category.label}</h2>
         </div>
         <div css={roomSettingBox}>
-          <span css={roomSettingLabel}>타이머</span>
+          <span css={roomSettingLabel}>제한 시간</span>
           <h2 css={smallTitle}>{roomSetting.timeLimit / 1000}초</h2>
         </div>
       </button>

--- a/frontend/src/components/common/Dropdown/Dropdown.stories.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown.stories.tsx
@@ -14,12 +14,12 @@ const meta = {
     optionList: {
       description: '드랍다운 내에 들어갈 옵션 배열을 넘겨줄 수 있습니다.',
     },
-    handleClick: {
+    handleClickOption: {
       description: '옵션을 선택했을 때 동작하는 이벤트 핸들러입니다.',
     },
   },
   args: {
-    handleClick: fn(),
+    handleClickOption: fn(),
   },
 } satisfies Meta<typeof Dropdown>;
 
@@ -52,7 +52,7 @@ export const 기본_드랍다운: Story = {
             label: '음식',
           },
         ]}
-        handleClick={(e) => setText(e.currentTarget.value)}
+        handleClickOption={(e) => setText(e.currentTarget.value)}
       />
     );
   },

--- a/frontend/src/components/common/Dropdown/Dropdown.styled.ts
+++ b/frontend/src/components/common/Dropdown/Dropdown.styled.ts
@@ -7,7 +7,7 @@ export const dropdownLayout = css`
   position: relative;
   align-items: center;
 
-  width: 12rem;
+  width: 16rem;
   height: 3.6rem;
   padding: 0.8rem;
   border: 1px solid black;

--- a/frontend/src/components/common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown.tsx
@@ -45,10 +45,10 @@ const Dropdown = <T extends { value: string; label: string }>({
       }
     };
 
-    document.addEventListener('mousedown', handleOutsideClose);
+    document.addEventListener('click', handleOutsideClose);
 
     return () => {
-      document.removeEventListener('mousedown', handleOutsideClose);
+      document.removeEventListener('click', handleOutsideClose);
     };
   }, [isOpen]);
 
@@ -66,7 +66,7 @@ const Dropdown = <T extends { value: string; label: string }>({
         <div css={emptyWrapper}></div>
         <span css={dropdownText}>{text || '선택해주세요'}</span>
         <div>
-          <img src={isOpen ? ArrowUp : ArrowDown} alt="" css={arrowImage} aria-hidden="true" />
+          <img src={isOpen ? ArrowUp : ArrowDown} alt="" css={arrowImage} />
         </div>
       </button>
 

--- a/frontend/src/components/common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown.tsx
@@ -16,7 +16,7 @@ import ArrowUp from '@/assets/images/arrowUp.svg';
 interface DropdownProps<T> {
   text: string;
   optionList: T[];
-  handleClickOption: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  handleClickOption: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const Dropdown = <T extends { value: string; label: string }>({

--- a/frontend/src/components/common/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown.tsx
@@ -16,64 +16,80 @@ import ArrowUp from '@/assets/images/arrowUp.svg';
 interface DropdownProps<T> {
   text: string;
   optionList: T[];
-  handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  handleClickOption: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 const Dropdown = <T extends { value: string; label: string }>({
   text,
   optionList,
-  handleClick,
+  handleClickOption,
 }: DropdownProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
   const handleToggleDropdown = () => {
     setIsOpen((prev) => !prev);
+    triggerRef.current?.focus();
+  };
+
+  const handleSelectOption = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    handleClickOption(e);
+    handleToggleDropdown();
   };
 
   useEffect(() => {
     const handleOutsideClose = (e: MouseEvent) => {
-      const isOutsideDropdown = isOpen && !dropdownRef.current?.contains(e.target as Element);
-
-      if (isOutsideDropdown) {
+      if (isOpen && dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setIsOpen(false);
       }
     };
 
-    document.addEventListener('click', handleOutsideClose);
+    document.addEventListener('mousedown', handleOutsideClose);
 
-    return () => document.removeEventListener('click', handleOutsideClose);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClose);
+    };
   }, [isOpen]);
 
   return (
-    <div
-      css={dropdownLayout}
-      ref={dropdownRef}
-      onClick={handleToggleDropdown}
-      onKeyDown={handleToggleDropdown}
-      role="button"
-      tabIndex={0}
-    >
-      <div css={dropdownTextContainer}>
+    <div css={dropdownLayout} ref={dropdownRef}>
+      <button
+        ref={triggerRef}
+        onClick={handleToggleDropdown}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls="dropdown-listbox"
+        aria-label={`카테고리 선택 목록, 현재 선택: ${text || '선택해주세요'}`}
+        css={dropdownTextContainer}
+      >
         <div css={emptyWrapper}></div>
         <span css={dropdownText}>{text || '선택해주세요'}</span>
         <div>
-          <img src={isOpen ? ArrowDown : ArrowUp} alt="드랍다운 화살표" css={arrowImage} />
+          <img src={isOpen ? ArrowUp : ArrowDown} alt="" css={arrowImage} aria-hidden="true" />
         </div>
-      </div>
-      <ul css={selectOptionList(isOpen, optionList.length)}>
-        {isOpen &&
-          optionList.map((option) => (
-            <li key={option.value}>
+      </button>
+
+      {isOpen && (
+        <ul
+          id="dropdown-listbox"
+          role="listbox"
+          aria-labelledby="dropdown-button"
+          css={selectOptionList(isOpen, optionList.length)}
+        >
+          {optionList.map((option) => (
+            <li key={option.value} role="option" aria-selected={text === option.label}>
               <button
                 css={optionButton(text === option.label)}
                 value={option.value}
-                onClick={handleClick}
+                onClick={handleSelectOption}
               >
                 {option.label}
               </button>
             </li>
           ))}
-      </ul>
+        </ul>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/common/Modal/Modal.styled.ts
+++ b/frontend/src/components/common/Modal/Modal.styled.ts
@@ -20,7 +20,7 @@ export const modalContentWrapper = ({ position }: Pick<ModalProps, 'position'>) 
   left: 50%;
   flex-direction: column;
   gap: 1.6rem;
-  width: 24rem;
+  width: 28rem;
   height: fit-content;
   max-height: 70vh;
   min-height: 1.2rem;

--- a/frontend/src/components/common/RoomSettingModal/CategoryDropdown/CategoryDropdown.tsx
+++ b/frontend/src/components/common/RoomSettingModal/CategoryDropdown/CategoryDropdown.tsx
@@ -17,7 +17,11 @@ const CategoryDropdown = ({ category, handleClickOption }: CategoryDropdownProps
   if (!categoryList || !category) return <div>카테고리가 없습니다.</div>;
 
   return (
-    <Dropdown<Category> text={category} optionList={categoryList} handleClick={handleClickOption} />
+    <Dropdown<Category>
+      text={category}
+      optionList={categoryList}
+      handleClickOption={handleClickOption}
+    />
   );
 };
 

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
@@ -5,6 +5,7 @@ import { Theme } from '@/styles/Theme';
 export const roomSettingTitleContainer = css`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 1rem;
 `;
 

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
@@ -21,5 +21,5 @@ export const roomSettingTitle = css`
 export const roomSettingButtonContainer = css`
   display: flex;
   justify-content: center;
-  gap: 1.6rem;
+  gap: 1rem;
 `;

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.styled.ts
@@ -21,5 +21,5 @@ export const roomSettingTitle = css`
 export const roomSettingButtonContainer = css`
   display: flex;
   justify-content: center;
-  gap: 1rem;
+  gap: 1.6rem;
 `;

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
@@ -20,7 +20,8 @@ const RoomSettingContainer = ({
       <div css={roomSettingTitleWrapper}>
         <span css={roomSettingTitle}>{title}</span>
       </div>
-      <ul css={roomSettingButtonContainer}>{children}</ul>
+      {title === '카테고리' && children}
+      {title !== '카테고리' && <ul css={roomSettingButtonContainer}>{children}</ul>}
     </div>
   );
 };

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
@@ -20,8 +20,9 @@ const RoomSettingContainer = ({
       <div css={roomSettingTitleWrapper}>
         <span css={roomSettingTitle}>{title}</span>
       </div>
-      {title === '카테고리' && children}
-      {title !== '카테고리' && (
+      {title === '카테고리' ? (
+        children
+      ) : (
         <ul css={roomSettingButtonContainer} role="radiogroup">
           {children}
         </ul>

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
@@ -21,7 +21,11 @@ const RoomSettingContainer = ({
         <span css={roomSettingTitle}>{title}</span>
       </div>
       {title === '카테고리' && children}
-      {title !== '카테고리' && <ul css={roomSettingButtonContainer}>{children}</ul>}
+      {title !== '카테고리' && (
+        <ul css={roomSettingButtonContainer} role="radiogroup">
+          {children}
+        </ul>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingContainer/RoomSettingContainer.tsx
@@ -8,7 +8,7 @@ import {
 } from './RoomSettingContainer.styled';
 
 interface RoomSettingContainerProps {
-  title: '카테고리' | '총 라운드' | '라운드 당 타이머';
+  title: '카테고리' | '총 라운드' | '제한 시간';
 }
 
 const RoomSettingContainer = ({

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingModal.test.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingModal.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, screen, waitFor } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 
 import RoomSettingModal from './RoomSettingModal';
 
@@ -28,44 +28,58 @@ describe('RoomSettingModal 방 설정 모달 테스트', () => {
 
   it('방의 카테고리를 변경한 후 적용 버튼을 클릭하면 카테고리 설정이 변경된다.', async () => {
     const user = userEvent.setup();
-    const CATEGORY = '연애';
+    const NEW_CATEGORY = '음식';
+
     const clickButton = async (name: string) => {
       const button = await screen.findByRole('button', { name });
       await user.click(button);
     };
 
-    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
     customRender(<RoomSettingModal isOpen={true} onClose={jest.fn()} />);
+    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
 
     await waitFor(() => {
       expect(result.current.roomSetting).toEqual(ROOM_INFO.roomSetting);
     });
 
-    await clickButton('음식 드랍다운 화살표');
-    await clickButton(CATEGORY);
+    const dropdownButton = await screen.findByRole('button', {
+      name: /선택해주세요|카테고리 선택/,
+    });
+    await user.click(dropdownButton);
+
+    const categoryOption = await screen.findByRole('option', { name: NEW_CATEGORY });
+    await user.click(categoryOption);
+
     await clickButton('적용');
 
     await waitFor(() => {
-      expect(result.current.roomSetting?.category.label).toBe(CATEGORY);
+      expect(result.current.roomSetting?.category.label).toBe(NEW_CATEGORY);
     });
   });
 
   it('방의 총 라운드를 변경한 후 적용 버튼을 클릭하면 총 라운드 설정이 변경된다.', async () => {
     const user = userEvent.setup();
     const TOTAL_ROUND = 7;
+
+    const clickRadio = async (name: string) => {
+      const radio = await screen.findByRole('radio', { name });
+      await user.click(radio);
+    };
+
     const clickButton = async (name: string) => {
       const button = await screen.findByRole('button', { name });
       await user.click(button);
     };
 
-    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
     customRender(<RoomSettingModal isOpen={true} onClose={jest.fn()} />);
+    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
 
     await waitFor(() => {
       expect(result.current.roomSetting).toEqual(ROOM_INFO.roomSetting);
     });
 
-    await clickButton(TOTAL_ROUND.toString());
+    await clickRadio(TOTAL_ROUND.toString());
+
     await clickButton('적용');
 
     await waitFor(() => {
@@ -76,19 +90,26 @@ describe('RoomSettingModal 방 설정 모달 테스트', () => {
   it('방의 라운드 당 타이머를 변경한 후 적용 버튼을 클릭하면 타이머 설정이 변경된다.', async () => {
     const user = userEvent.setup();
     const TIME_LIMIT = 10000;
+
+    const clickRadio = async (name: string) => {
+      const radio = await screen.findByRole('radio', { name });
+      await user.click(radio);
+    };
+
     const clickButton = async (name: string) => {
       const button = await screen.findByRole('button', { name });
       await user.click(button);
     };
 
-    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
     customRender(<RoomSettingModal isOpen={true} onClose={jest.fn()} />);
+    const { result } = renderHook(() => useGetRoomInfo(), { wrapper });
 
     await waitFor(() => {
       expect(result.current.roomSetting).toEqual(ROOM_INFO.roomSetting);
     });
 
-    await clickButton(`${TIME_LIMIT / POLLING_DELAY}초`);
+    await clickRadio(`${TIME_LIMIT / POLLING_DELAY}초`);
+
     await clickButton('적용');
 
     await waitFor(() => {

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
@@ -12,7 +12,7 @@ import Modal from '../Modal/Modal';
 import { POLLING_DELAY } from '@/constants/config';
 
 const TOTAL_ROUND_LIST = [5, 7, 10];
-const TIMER_PER_ROUND_LIST = [5000, 10000, 15000];
+const TIMER_PER_ROUND_LIST = [10000, 15000, 30000, 60000];
 
 interface RoomSettingModalProps {
   isOpen: boolean;

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
@@ -50,7 +50,7 @@ const RoomSettingModal = ({ isOpen, onClose }: RoomSettingModalProps) => {
               </li>
             ))}
           </RoomSettingContainer>
-          <RoomSettingContainer title="라운드 당 타이머">
+          <RoomSettingContainer title="제한 시간">
             {TIMER_PER_ROUND_LIST.map((timeLimit) => (
               <li key={timeLimit}>
                 <button

--- a/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
+++ b/frontend/src/components/common/RoomSettingModal/RoomSettingModal.tsx
@@ -44,7 +44,12 @@ const RoomSettingModal = ({ isOpen, onClose }: RoomSettingModalProps) => {
           <RoomSettingContainer title="총 라운드">
             {TOTAL_ROUND_LIST.map((round) => (
               <li key={round}>
-                <button css={roomSettingButton(totalRound === round)} onClick={handleClickRound}>
+                <button
+                  role="radio"
+                  onClick={handleClickRound}
+                  aria-checked={totalRound === round}
+                  css={roomSettingButton(totalRound === round)}
+                >
                   {round}
                 </button>
               </li>
@@ -54,9 +59,11 @@ const RoomSettingModal = ({ isOpen, onClose }: RoomSettingModalProps) => {
             {TIMER_PER_ROUND_LIST.map((timeLimit) => (
               <li key={timeLimit}>
                 <button
-                  css={roomSettingButton(timeLimitPerRound === timeLimit)}
+                  role="radio"
                   onClick={handleClickTimeLimit}
                   value={timeLimit}
+                  aria-checked={timeLimitPerRound === timeLimit}
+                  css={roomSettingButton(timeLimitPerRound === timeLimit)}
                 >
                   {timeLimit / POLLING_DELAY}초
                 </button>

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -139,6 +139,10 @@ const reset = css`
     background-color: inherit;
     outline: none;
     cursor: pointer;
+
+    :enabled {
+      color: black;
+    }
   }
 `;
 


### PR DESCRIPTION
## Issue Number
#352 

## As-Is
<!-- 문제 상황 정의 -->
## 개선 전

https://github.com/user-attachments/assets/ad5b1b73-25cc-43a1-ab20-0fd90d09980a


## 문제점
### 카테고리 선택 목록
1. 어떤 선택 목록인지 알 수 없다.
2. 목록이 열려있고 스와이프 했을 때 요소로 넘어가지 못한다. 
3. 목록 중 몇 번째인지 알 수 없다.
4. 목록 중 어느 것이 선택되어 있는지 알 수 없다. 
5. 선택 후 포커스를 잃는다.

### 라운드, 제한 시간
1. 어떤 설정 값이 선택되어 있는지 알 수 없다. 
2. 몇 개의 목록 중 몇 번째인지 알 수 없다.

## To-Be
<!-- 변경 사항 -->
## 개선 후

https://github.com/user-attachments/assets/274c8a2d-36e9-42ba-9709-3d700e3bd27b


### 선택 목록
- [x] 어떤 선택 목록인지 알 수 있다.
> 📢 카테고리 선택 목록, 현재 선택: 연애, 팝업 버튼, 상자 팝업, 피커를 활성화 하려면 이중탭 하십시오.
- [x]  목록이 열려있고 스와이프를 했을 때 다음 요소를 읽을 수 있다. 
> 📢 카테고리 선택 목록 -> 연애 -> 만약에 -> MBTI -> 음식
- [x] 목록의 시작과 끝을 알 수 있다. 
> 📢 연애 목록 시작 -> ... -> 음식 목록 끝
- [x] 해당 옵션이 선택되어 있는지 알 수 있다.
 > 📢 선택됨 음식
- [x] 옵션 선택 후 포커스가 다시 선택 목록이 된다.

### 라운드, 제한 시간 
- [x] 어떤 설정 값이 선택되어 있는지 알 수 있다. 
 > 📢 5 선택 버튼 선택됨
- [x] 몇 개의 옵션 중 몇 번째인지 알 수 없다.
 > 📢총 3개 중 1번째

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
해당 자료들을 참고하였습니다 ✨
https://nuli.navercorp.com/community/article/1133219
https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/