### PR TITLE
[REFACTOR] 다중 서버 환경에서 Logging의 Observability 개선하기

### DIFF
--- a/backend/src/main/java/ddangkong/aop/logging/ControllerLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ControllerLoggingAspect.java
@@ -4,16 +4,19 @@ import static java.util.stream.Collectors.joining;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Parameter;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.MDC;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Slf4j
 abstract class ControllerLoggingAspect {
+    private static final String TRACE_ID_KEY = "traceId";
 
     @Pointcut("execution(* ddangkong.controller..*Controller.*(..))")
     public void allController() {
@@ -28,6 +31,7 @@ abstract class ControllerLoggingAspect {
     }
 
     protected void logControllerRequest(JoinPoint joinPoint) {
+        setTraceId();
         HttpServletRequest request = getHttpServletRequest();
         String uri = request.getRequestURI();
         String httpMethod = request.getMethod();
@@ -43,6 +47,7 @@ abstract class ControllerLoggingAspect {
         String httpMethod = request.getMethod();
 
         log.info("Response Logging: SUCCESS {} {} Body: {}", httpMethod, uri, responseBody);
+        removeTraceId();
     }
 
     private HttpServletRequest getHttpServletRequest() {
@@ -75,5 +80,14 @@ abstract class ControllerLoggingAspect {
             }
         }
         return null;
+    }
+
+    private void setTraceId() {
+        String traceId = UUID.randomUUID().toString();
+        MDC.put(TRACE_ID_KEY, traceId);
+    }
+
+    private void removeTraceId() {
+        MDC.remove(TRACE_ID_KEY);
     }
 }

--- a/backend/src/main/java/ddangkong/aop/logging/ControllerLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ControllerLoggingAspect.java
@@ -46,7 +46,7 @@ abstract class ControllerLoggingAspect {
         String uri = request.getRequestURI();
         String httpMethod = request.getMethod();
 
-        log.info("Response Logging: SUCCESS {} {} Body: {}", httpMethod, uri, responseBody);
+        log.info("Response Logging: {} {} Body: {}", httpMethod, uri, responseBody);
         removeTraceId();
     }
 

--- a/backend/src/main/java/ddangkong/aop/logging/ProdControllerLoggingAspect.java
+++ b/backend/src/main/java/ddangkong/aop/logging/ProdControllerLoggingAspect.java
@@ -2,6 +2,7 @@ package ddangkong.aop.logging;
 
 
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.context.annotation.Profile;
@@ -15,5 +16,10 @@ public class ProdControllerLoggingAspect extends ControllerLoggingAspect {
     @Before("allControllerWithoutPolling()")
     public void logControllerRequest(JoinPoint joinPoint) {
         super.logControllerRequest(joinPoint);
+    }
+
+    @AfterReturning(pointcut = "allControllerWithoutPolling()", returning = "responseBody")
+    protected void logControllerResponse(JoinPoint joinPoint, Object responseBody) {
+        super.logControllerResponse(joinPoint, responseBody);
     }
 }

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -11,7 +11,7 @@
             <maxHistory>14</maxHistory> <!-- 14일간 보관 -->
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [traceId=%X{traceId}] - %msg%n
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
             </pattern>
         </encoder>
     </appender>
@@ -21,7 +21,7 @@
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [traceId=%X{traceId}] -
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [%X{traceId:-NoTraceID}] -
                 %msg%n```%ex{full}```
             </pattern>
         </layout>

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -11,7 +11,8 @@
             <maxHistory>14</maxHistory> <!-- 14일간 보관 -->
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [traceId=%X{traceId}] - %msg%n
+            </pattern>
         </encoder>
     </appender>
 
@@ -20,7 +21,8 @@
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [traceId=%X{traceId}] -
+                %msg%n```%ex{full}```
             </pattern>
         </layout>
         <username>dev-error-alert-bot</username>

--- a/backend/src/main/resources/logback-prod.xml
+++ b/backend/src/main/resources/logback-prod.xml
@@ -10,7 +10,8 @@
             <maxHistory>365</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [traceId=%X{traceId}] - %msg%n
+            </pattern>
         </encoder>
     </appender>
 
@@ -19,7 +20,8 @@
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [traceId=%X{traceId}] -
+                %msg%n```%ex{full}```
             </pattern>
         </layout>
         <username>prod-error-alert-bot</username>

--- a/backend/src/main/resources/logback-prod.xml
+++ b/backend/src/main/resources/logback-prod.xml
@@ -10,7 +10,7 @@
             <maxHistory>365</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [traceId=%X{traceId}] - %msg%n
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
             </pattern>
         </encoder>
     </appender>
@@ -20,7 +20,7 @@
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
         <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [traceId=%X{traceId}] -
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] [%-5level] %logger{36} [%X{traceId:-NoTraceID}] -
                 %msg%n```%ex{full}```
             </pattern>
         </layout>


### PR DESCRIPTION
## Issue Number
#355 

## As-Is
<!-- 문제 상황 정의 -->
#355 
이슈 참조 부탁드립니다.

## To-Be
<!-- 변경 사항 -->
해결방안으로 떠올린 방법은 **MDC**를 사용하는 것이다.

요청이 도착했을 때, 각 요청마다 **TraceID(UUID)** 를 생성하고, **MDC**에 삽입한다.

그리고 Log를 찍을 때 해당 정보를 함께 표시해준다.

그럼 요청별로 구분하는 것이 굉장히 쉽게 변할 것이라고 생각했다.

### **MDC (Mapped Diagnostic Context) 란?**

**MDC**는 주로 로그 관리에서 사용하는 개념으로, **스레드 로컬(Thread Local)** 변수를 통해 각 스레드별로 고유한 컨텍스트 데이터를 저장하고,
이를 로그에 포함시키는 기능을 제공한다.

스프링 부트와 같은 환경에서 요청 단위로 고유한 **TraceID**를 생성해 로그에 삽입할 때 자주 사용된다.

**[MDC의 주요 기능]**

- **스레드별로 독립된 데이터**를 관리할 수 있습니다. 이는 특히 **멀티스레드** 환경에서 유용하다.
- 특정 요청이나 작업에 관련된 메타데이터를 로그에 자동으로 삽입할 수 있다. 예를 들어, `TraceID`, 사용자 ID, 세션 ID 등과 같은 정보를 로그 메시지에 포함할 수 있다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/396a68f2-f227-45bf-a48d-209d40b6174e">


## (Optional) Additional Description
