### PR TITLE
[FEAT] 하루 지난 로그 gz으로 압축하여 관리

### DIFF
--- a/backend/src/main/resources/logback-prod.xml
+++ b/backend/src/main/resources/logback-prod.xml
@@ -6,7 +6,7 @@
     <appender name="DDANGKONG_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/ddangkong.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/ddangkong-%d{yyyy-MM-dd}.log</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
+            <fileNamePattern>${LOG_PATH}/ddangkong-%d{yyyy-MM-dd}.log.gz</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
             <maxHistory>365</maxHistory>
         </rollingPolicy>
         <encoder>


### PR DESCRIPTION
## Issue Number
#359 

## As-Is
<!-- 문제 상황 정의 -->
Loki에서 로그 정보를 수집하여 Grafana에서 확인할 수 있기 때문에 운영환경에서 log를 자주 열람하지 않는다.
때문에 하루가 지난 로그는 gz 형태로 구성하여 저장공간을 절약한다.
> dev 환경은 스프린트에서 개발을 진행하며 자주 열람하기도 하고, 스프린트 단위인 2주 단위로 제거되므로 압축설정을 하지 않는다.

## To-Be
<!-- 변경 사항 -->
일자가 지난 로그는 `gz`으로 압축하여 관리

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="299" alt="image" src="https://github.com/user-attachments/assets/3dea4adf-ae9e-47ca-bd4c-2f5b12158e5d">


## (Optional) Additional Description
