### PR TITLE
[REFACTOR] 접근성 컴포넌트 A11yOnly 리팩토링 및 추가 접근성 코드 리팩토링

### DIFF
--- a/frontend/src/components/OptionParticipants/OptionParticipants.tsx
+++ b/frontend/src/components/OptionParticipants/OptionParticipants.tsx
@@ -13,11 +13,10 @@ export interface OptionParticipantsProps {
 }
 
 const OptionParticipants = ({ optionName, memberCount, members }: OptionParticipantsProps) => {
+  const screenReaderOptionParticipants = `${optionName}. ${memberCount}명`;
   return (
     <div css={optionParticipantsLayout}>
-      <A11yOnly>
-        {optionName}.{memberCount}명
-      </A11yOnly>
+      <A11yOnly>{screenReaderOptionParticipants}</A11yOnly>
       <p css={optionInfo} aria-hidden>
         {optionName}: {memberCount}
       </p>

--- a/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
+++ b/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
@@ -41,7 +41,7 @@ const ReadyMembersContainer = () => {
   return (
     <section css={readyMembersContainerLayout}>
       <div css={totalNumber}>
-        <div role="status">총 인원 ${members.length}명</div>
+        <div role="status">총 인원 {members.length}명</div>
         <button css={inviteButton} onClick={handleClickInvite} ref={returnFocusRef}>
           초대하기
         </button>

--- a/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
+++ b/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
@@ -26,6 +26,7 @@ const ReadyMembersContainer = () => {
   const { show } = useModal();
   const [memberInfo, setMemberInfo] = useRecoilState(memberInfoState);
   const returnFocusRef = useRef<HTMLButtonElement>(null);
+  const memberCountMessage = `총 인원 ${members.length}명`;
 
   const handleClickInvite = () => {
     show(InviteModal, { returnFocusRef });
@@ -41,7 +42,7 @@ const ReadyMembersContainer = () => {
   return (
     <section css={readyMembersContainerLayout}>
       <div css={totalNumber}>
-        <div role="status">총 인원 {members.length}명</div>
+        <div role="status">{memberCountMessage}</div>
         <button css={inviteButton} onClick={handleClickInvite} ref={returnFocusRef}>
           초대하기
         </button>

--- a/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
+++ b/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
@@ -40,9 +40,8 @@ const ReadyMembersContainer = () => {
 
   return (
     <section css={readyMembersContainerLayout}>
-      <A11yOnly aria-live="polite">총 인원 {members.length}명</A11yOnly>
       <div css={totalNumber}>
-        <div aria-hidden>총 인원 {members.length}명</div>
+        <div role="status">{`총 인원 ${members.length}명`}</div>
         <button css={inviteButton} onClick={handleClickInvite} ref={returnFocusRef}>
           초대하기
         </button>

--- a/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
+++ b/frontend/src/components/ReadyMembersContainer/ReadyMembersContainer.tsx
@@ -41,7 +41,7 @@ const ReadyMembersContainer = () => {
   return (
     <section css={readyMembersContainerLayout}>
       <div css={totalNumber}>
-        <div role="status">{`총 인원 ${members.length}명`}</div>
+        <div role="status">총 인원 ${members.length}명</div>
         <button css={inviteButton} onClick={handleClickInvite} ref={returnFocusRef}>
           초대하기
         </button>

--- a/frontend/src/components/SelectContainer/SelectContainer.test.tsx
+++ b/frontend/src/components/SelectContainer/SelectContainer.test.tsx
@@ -25,7 +25,7 @@ describe('SelectContainer', () => {
 
     customRender(<SelectContainer />);
 
-    const optionButton = await screen.findByRole('button', { name: SELECT_OPTION });
+    const optionButton = await screen.findByRole('radio', { name: SELECT_OPTION });
     await user.click(optionButton);
 
     const selectButton = await screen.findByRole('button', { name: '선택' });

--- a/frontend/src/components/SelectContainer/SelectContainer.tsx
+++ b/frontend/src/components/SelectContainer/SelectContainer.tsx
@@ -20,7 +20,7 @@ const SelectContainer = () => {
         isVoted={selectedOption.isCompleted}
         completeSelection={completeSelection}
       />
-      <section css={selectSection}>
+      <section role="radiogroup" css={selectSection}>
         <SelectOption
           option={balanceContent.firstOption}
           selectedOption={selectedOption}

--- a/frontend/src/components/SelectContainer/Timer/Timer.tsx
+++ b/frontend/src/components/SelectContainer/Timer/Timer.tsx
@@ -31,7 +31,7 @@ const Timer = ({ selectedId, isVoted, completeSelection }: TimerProps) => {
     isVoted,
     completeSelection,
   });
-  const ScreenReaderLeftRoundTime = `${leftRoundTime}초 남았습니다.`;
+  const screenReaderLeftRoundTime = `${leftRoundTime}초 남았습니다.`;
 
   useVoteIsFinished({
     contentId: balanceContent.contentId,
@@ -44,7 +44,7 @@ const Timer = ({ selectedId, isVoted, completeSelection }: TimerProps) => {
       <div css={timerWrapper(timeLimit)}>
         <img css={[timerIcon, isAlmostFinished && timerIconShake]} src={DdangkongTimer} alt="" />
         <A11yOnly role="alert" aria-live={isAlertTimer(leftRoundTime, timeLimit) && 'assertive'}>
-          {ScreenReaderLeftRoundTime}
+          {screenReaderLeftRoundTime}
         </A11yOnly>
         <span css={timerText(isAlmostFinished)} aria-hidden>
           {formatLeftRoundTime(leftRoundTime)}

--- a/frontend/src/components/SelectContainer/Timer/Timer.tsx
+++ b/frontend/src/components/SelectContainer/Timer/Timer.tsx
@@ -31,6 +31,7 @@ const Timer = ({ selectedId, isVoted, completeSelection }: TimerProps) => {
     isVoted,
     completeSelection,
   });
+  const ScreenReaderLeftRoundTime = `${leftRoundTime}초 남았습니다.`;
 
   useVoteIsFinished({
     contentId: balanceContent.contentId,
@@ -42,8 +43,8 @@ const Timer = ({ selectedId, isVoted, completeSelection }: TimerProps) => {
       <div css={timerInnerLayout(timeLimit)}></div>
       <div css={timerWrapper(timeLimit)}>
         <img css={[timerIcon, isAlmostFinished && timerIconShake]} src={DdangkongTimer} alt="" />
-        <A11yOnly aria-live={isAlertTimer(leftRoundTime, timeLimit) && 'polite'}>
-          {leftRoundTime}초 남았습니다.
+        <A11yOnly role="alert" aria-live={isAlertTimer(leftRoundTime, timeLimit) && 'assertive'}>
+          {ScreenReaderLeftRoundTime}
         </A11yOnly>
         <span css={timerText(isAlmostFinished)} aria-hidden>
           {formatLeftRoundTime(leftRoundTime)}

--- a/frontend/src/components/SelectContainer/Timer/Timer.util.ts
+++ b/frontend/src/components/SelectContainer/Timer/Timer.util.ts
@@ -15,7 +15,7 @@ export const convertMsecToSecond = (msec: number) => {
   return msec / UNIT_MSEC;
 };
 
-// Timer가 스크린 리더에 읽혀야하는 시점에 aria-live="polite" 설정하도록 boolean 값 반환 (제한 시간 절반 & 5초 남았을 때)
+// Timer가 스크린 리더에 읽혀야하는 시점에 aria-live="assertive" 설정하도록 boolean 값 반환 (제한 시간 절반 & 5초 남았을 때)
 export const isAlertTimer = (leftRoundTime: number, timeLimit: number) => {
   return leftRoundTime === Math.floor(timeLimit / 2) || leftRoundTime === ALMOST_FINISH_SECOND;
 };

--- a/frontend/src/components/SelectOption/SelectOption.tsx
+++ b/frontend/src/components/SelectOption/SelectOption.tsx
@@ -18,10 +18,11 @@ const SelectOption = ({ option, selectedOption, handleClickOption }: SelectOptio
 
   return (
     <button
+      role="radio"
       css={SelectOptionLayout(selectedId === option.optionId, isCompleted)}
       onClick={() => handleClickOption(option.optionId)}
       disabled={isCompleted}
-      aria-pressed={selectedId === option.optionId}
+      aria-checked={selectedId === option.optionId}
     >
       {option.name}
     </button>

--- a/frontend/src/components/common/SelectButton/SelectButton.tsx
+++ b/frontend/src/components/common/SelectButton/SelectButton.tsx
@@ -18,7 +18,6 @@ const SelectButton = ({ contentId, selectedId, completeSelection }: SelectButton
     contentId,
     completeSelection,
   });
-
   return (
     <div css={bottomButtonLayout}>
       <Button
@@ -26,7 +25,6 @@ const SelectButton = ({ contentId, selectedId, completeSelection }: SelectButton
         disabled={data || !selectedId || isPending}
         text={data || isPending ? '선택 완료' : '선택'}
         onClick={vote}
-        aria-pressed={data}
       />
     </div>
   );

--- a/frontend/src/components/common/a11yOnly/A11yOnly.tsx
+++ b/frontend/src/components/common/a11yOnly/A11yOnly.tsx
@@ -9,13 +9,12 @@ interface A11yOnlyProps<T extends ElementType = 'span'> {
 
 const A11yOnly = <T extends ElementType = 'span'>({
   as,
-  role = 'text',
   children,
   ...props
 }: PropsWithChildren<A11yOnlyProps<T>>) => {
   const Component = as || 'span';
   return (
-    <Component css={a11yOnlyLayout} role={role} {...props}>
+    <Component css={a11yOnlyLayout} {...props}>
       {children}
     </Component>
   );

--- a/frontend/src/components/layout/Header/Header.styled.ts
+++ b/frontend/src/components/layout/Header/Header.styled.ts
@@ -8,6 +8,10 @@ export const headerLayout = (isCenter?: boolean) => css`
   align-items: center;
   height: 12vh;
   padding: 0 2.4rem;
+
+  :focus {
+    outline: none;
+  }
 `;
 
 export const roundText = css`


### PR DESCRIPTION
## Issue Number
#361 

## As-Is
<!-- 문제 상황 정의 -->
1. role="text"는 표준으로 정의되어 있지 않은 속성인데 임의로 사용하고 있다. 
2. 몇 가지 컴포넌트에서 접근성 코드의 개선이 필요하다. 

## To-Be
<!-- 변경 사항 -->
### A11yOnly
- [x] role 속성을 정의하지 않으면 text를 기본으로 설정한 코드를 삭제
- [x] 사용처에서 필요한 수정

### 게임 타이머
- [x] role="alert" 속성을 추가한다. 암묵적으로 aria-live="assertive", aria-atomic=true를 포함한다. 
> status가 아니라 alert를 사용한 이유는 1) 매 초 남은 시간을 안내하는 것이 아니라 제한 시간 시작, 중간, 5초 남았을 때에 안내하기 때문이다. 2) 선택지를 **제한 시간**안에 골라야 하기 때문에 긴급한 알림이라고 판단하였다.  

### 대기 방 인원
- [x] role="status" 속성을 추가한다. 암묵적으로 aria-live="polite", aria-atomic=true를 포함한다.

### 게임 선택지
- [x] 선택지 두 개를 감싸는 태그를 role="radiogroup"을 설정하고 하단 버튼을 role="radio"로 설정, aria-checked를 추가하여 선택됨 또는 선택되지 않음을 알려준다.
> 두 개 중 하나를 선택하는 것이라 라디오의 성격을 가진다고 생각했다. 

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/