### PR TITLE
[FIX] 쿠키 설정 변경 

### DIFF
--- a/backend/src/docs/asciidoc/room.adoc
+++ b/backend/src/docs/asciidoc/room.adoc
@@ -58,27 +58,27 @@ include::{snippets}/room/join/response-cookies.adoc[]
 
 '''
 
-=== 방 재참여
+=== 사용자 정보 조회
 
 ==== curl
 
-include::{snippets}/room/rejoin/curl-request.adoc[]
+include::{snippets}/room/member/curl-request.adoc[]
 
 ==== request
 
-include::{snippets}/room/rejoin/http-request.adoc[]
+include::{snippets}/room/member/http-request.adoc[]
 
 request cookies
 
-include::{snippets}/room/rejoin/request-cookies.adoc[]
+include::{snippets}/room/member/request-cookies.adoc[]
 
 ==== response
 
-include::{snippets}/room/rejoin/http-response.adoc[]
+include::{snippets}/room/member/http-response.adoc[]
 
 response fields
 
-include::{snippets}/room/join/response-fields.adoc[]
+include::{snippets}/room/member/response-fields.adoc[]
 
 '''
 

--- a/backend/src/main/java/ddangkong/config/CorsConfig.java
+++ b/backend/src/main/java/ddangkong/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(corsOrigin)
+                .allowedOriginPatterns(corsOrigin)
                 .allowedMethods(
                         HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name()
                 )

--- a/backend/src/main/java/ddangkong/config/CorsConfig.java
+++ b/backend/src/main/java/ddangkong/config/CorsConfig.java
@@ -9,9 +9,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    private final String corsOrigin;
+    private final String[] corsOrigin;
 
-    public CorsConfig(@Value("${cors.origin}") String corsOrigin) {
+    public CorsConfig(@Value("${cors.origin}") String[] corsOrigin) {
         this.corsOrigin = corsOrigin;
     }
 
@@ -22,6 +22,7 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedMethods(
                         HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name()
                 )
+                .allowCredentials(true)
                 .allowedHeaders("*");
     }
 }

--- a/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 public class RejoinCookieEncryptor {
 
     private static final String SAME_SITE_OPTION = "None";
+    private static final String DEFAULT_PATH = "/balances/rooms";
 
     private final EncryptionUtils encryptionUtils;
 
@@ -23,6 +24,7 @@ public class RejoinCookieEncryptor {
         return ResponseCookie.from(rejoinKey, encrypt)
                 .httpOnly(true)
                 .secure(true)
+                .path(DEFAULT_PATH)
                 .sameSite(SAME_SITE_OPTION)
                 .build();
     }

--- a/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class RejoinCookieEncryptor {
 
     private static final String SAME_SITE_OPTION = "None";
-    private static final String DEFAULT_PATH = "/balances/rooms";
+    private static final String DEFAULT_PATH = "/api/balances/rooms";
 
     private final EncryptionUtils encryptionUtils;
 

--- a/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
@@ -1,11 +1,13 @@
 package ddangkong.controller.room;
 
-import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RejoinCookieEncryptor {
+
+    private static final String SAME_SITE_OPTION = "None";
 
     private final EncryptionUtils encryptionUtils;
 
@@ -16,12 +18,13 @@ public class RejoinCookieEncryptor {
         this.rejoinKey = rejoinKey;
     }
 
-    public Cookie getEncodedCookie(Object value) {
+    public ResponseCookie getEncodedCookie(Object value) {
         String encrypt = encryptionUtils.encrypt(String.valueOf(value));
-        Cookie cookie = new Cookie(rejoinKey, encrypt);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        return cookie;
+        return ResponseCookie.from(rejoinKey, encrypt)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite(SAME_SITE_OPTION)
+                .build();
     }
 
     public Long getDecodedCookieValue(String cookieValue) {

--- a/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RejoinCookieEncryptor.java
@@ -18,7 +18,10 @@ public class RejoinCookieEncryptor {
 
     public Cookie getEncodedCookie(Object value) {
         String encrypt = encryptionUtils.encrypt(String.valueOf(value));
-        return new Cookie(rejoinKey, encrypt);
+        Cookie cookie = new Cookie(rejoinKey, encrypt);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        return cookie;
     }
 
     public Long getDecodedCookieValue(String cookieValue) {

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -6,6 +6,7 @@ import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
+import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
@@ -47,9 +48,9 @@ public class RoomController {
         return roomJoinResponse;
     }
 
-    @GetMapping("/balances/rooms/rejoin")
-    public RoomJoinResponse rejoinRoom(@CookieValue(name = "${cookie.rejoin-key}") String cookieValue) {
-        return roomFacade.rejoinRoom(rejoinCookieEncryptor.getDecodedCookieValue(cookieValue));
+    @GetMapping("/balances/rooms/member")
+    public RoomMemberResponse getRoomMemberInfo(@CookieValue(name = "${cookie.rejoin-key}") String cookieValue) {
+        return roomFacade.getRoomMemberInfo(rejoinCookieEncryptor.getDecodedCookieValue(cookieValue));
     }
 
     @Polling

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -126,8 +126,8 @@ public class RoomController {
     private void setEncryptCookie(HttpServletRequest request,
                                   HttpServletResponse response,
                                   Object cookieValue) {
-        String requestURI = request.getRequestURI();
-        ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(cookieValue, requestURI);
+        String requestURL = request.getRequestURL().toString();
+        ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(cookieValue, requestURL);
         response.addHeader(HttpHeaders.SET_COOKIE, encodedCookie.toString());
     }
 }

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -10,6 +10,7 @@ import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -38,19 +39,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoomController {
 
     private final RoomFacade roomFacade;
-    private final RejoinCookieEncryptor rejoinCookieEncryptor;
+    private final RoomMemberCookieEncryptor roomMemberCookieEncryptor;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/balances/rooms")
-    public RoomJoinResponse createRoom(@Valid @RequestBody RoomJoinRequest request, HttpServletResponse response) {
+    public RoomJoinResponse createRoom(@Valid @RequestBody RoomJoinRequest request,
+                                       HttpServletRequest httpRequest,
+                                       HttpServletResponse httpResponse) {
         RoomJoinResponse roomJoinResponse = roomFacade.createRoom(request.nickname());
-        setEncryptCookie(response, roomJoinResponse.member().memberId());
+        setEncryptCookie(httpRequest, httpResponse, roomJoinResponse.member().memberId());
         return roomJoinResponse;
     }
 
     @GetMapping("/balances/rooms/member")
     public RoomMemberResponse getRoomMemberInfo(@CookieValue(name = "${cookie.rejoin-key}") String cookieValue) {
-        return roomFacade.getRoomMemberInfo(rejoinCookieEncryptor.getDecodedCookieValue(cookieValue));
+        return roomFacade.getRoomMemberInfo(roomMemberCookieEncryptor.getDecodedCookieValue(cookieValue));
     }
 
     @Polling
@@ -70,9 +73,10 @@ public class RoomController {
     @PostMapping("/balances/rooms/{uuid}/members")
     public RoomJoinResponse joinRoom(@PathVariable String uuid,
                                      @Valid @RequestBody RoomJoinRequest request,
-                                     HttpServletResponse response) {
+                                     HttpServletRequest httpRequest,
+                                     HttpServletResponse httpResponse) {
         RoomJoinResponse roomJoinResponse = roomFacade.joinRoom(request.nickname(), uuid);
-        setEncryptCookie(response, roomJoinResponse.member().memberId());
+        setEncryptCookie(httpRequest, httpResponse, roomJoinResponse.member().memberId());
         return roomJoinResponse;
     }
 
@@ -119,8 +123,11 @@ public class RoomController {
         return roomFacade.isInitialRoom(roomId);
     }
 
-    private void setEncryptCookie(HttpServletResponse response, Object cookieValue) {
-        ResponseCookie encodedCookie = rejoinCookieEncryptor.getEncodedCookie(cookieValue);
+    private void setEncryptCookie(HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  Object cookieValue) {
+        String requestURI = request.getRequestURI();
+        ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(cookieValue, requestURI);
         response.addHeader(HttpHeaders.SET_COOKIE, encodedCookie.toString());
     }
 }

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -126,8 +126,8 @@ public class RoomController {
     private void setEncryptCookie(HttpServletRequest request,
                                   HttpServletResponse response,
                                   Object cookieValue) {
-        String requestURL = request.getRequestURL().toString();
-        ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(cookieValue, requestURL);
+        String origin = request.getHeader(HttpHeaders.ORIGIN);
+        ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(cookieValue, origin);
         response.addHeader(HttpHeaders.SET_COOKIE, encodedCookie.toString());
     }
 }

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -9,13 +9,14 @@ import ddangkong.facade.room.dto.RoomJoinResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -118,7 +119,7 @@ public class RoomController {
     }
 
     private void setEncryptCookie(HttpServletResponse response, Object cookieValue) {
-        Cookie encodedCookie = rejoinCookieEncryptor.getEncodedCookie(cookieValue);
-        response.addCookie(encodedCookie);
+        ResponseCookie encodedCookie = rejoinCookieEncryptor.getEncodedCookie(cookieValue);
+        response.addHeader(HttpHeaders.SET_COOKIE, encodedCookie.toString());
     }
 }

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -2,6 +2,7 @@ package ddangkong.controller.room;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -9,8 +10,6 @@ import org.springframework.stereotype.Component;
 public class RoomMemberCookieEncryptor {
 
     private static final String DEFAULT_PATH = "/api/balances/rooms";
-    private static final String NONE = "None";
-    private static final String LAX = "Lax";
     private static final String LOCALHOST = "http://localhost";
 
     private final EncryptionUtils encryptionUtils;
@@ -34,9 +33,9 @@ public class RoomMemberCookieEncryptor {
 
     private String getSameSiteOption(String origin) {
         if (origin != null && origin.startsWith(LOCALHOST)) {
-            return NONE;
+            return SameSite.NONE.attributeValue();
         }
-        return LAX;
+        return SameSite.LAX.attributeValue();
     }
 
     public Long getDecodedCookieValue(String cookieValue) {

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -23,19 +23,18 @@ public class RoomMemberCookieEncryptor {
         this.rejoinKey = rejoinKey;
     }
 
-    public ResponseCookie getEncodedCookie(Object value, String requestURL) {
+    public ResponseCookie getEncodedCookie(Object value, String origin) {
         String encrypt = encryptionUtils.encrypt(String.valueOf(value));
         return ResponseCookie.from(rejoinKey, encrypt)
                 .httpOnly(true)
                 .secure(true)
                 .path(DEFAULT_PATH)
-                .sameSite(getSameSiteOption(requestURL))
+                .sameSite(getSameSiteOption(origin))
                 .build();
     }
 
-    private String getSameSiteOption(String url) {
-        log.info("request url = {}", url);
-        if (url.startsWith(LOCALHOST)) {
+    private String getSameSiteOption(String origin) {
+        if (origin.startsWith(LOCALHOST)) {
             return NONE;
         }
         return LAX;

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -10,7 +10,7 @@ public class RoomMemberCookieEncryptor {
     private static final String DEFAULT_PATH = "/api/balances/rooms";
     private static final String NONE = "None";
     private static final String LAX = "Lax";
-    private static final String LOCALHOST = "localhost";
+    private static final String LOCALHOST = "http://localhost";
 
     private final EncryptionUtils encryptionUtils;
 
@@ -32,7 +32,7 @@ public class RoomMemberCookieEncryptor {
     }
 
     private String getSameSiteOption(String uri) {
-        if (uri.equals(LOCALHOST)) {
+        if (uri.startsWith(LOCALHOST)) {
             return NONE;
         }
         return LAX;

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -1,9 +1,11 @@
 package ddangkong.controller.room;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class RoomMemberCookieEncryptor {
 
@@ -31,8 +33,9 @@ public class RoomMemberCookieEncryptor {
                 .build();
     }
 
-    private String getSameSiteOption(String uri) {
-        if (uri.startsWith(LOCALHOST)) {
+    private String getSameSiteOption(String url) {
+        log.info("request url = {}", url);
+        if (url.startsWith(LOCALHOST)) {
             return NONE;
         }
         return LAX;

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -5,28 +5,37 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RejoinCookieEncryptor {
+public class RoomMemberCookieEncryptor {
 
-    private static final String SAME_SITE_OPTION = "None";
     private static final String DEFAULT_PATH = "/api/balances/rooms";
+    private static final String NONE = "None";
+    private static final String LAX = "Lax";
+    private static final String LOCALHOST = "localhost";
 
     private final EncryptionUtils encryptionUtils;
 
     private final String rejoinKey;
 
-    public RejoinCookieEncryptor(EncryptionUtils encryptionUtils, @Value("${cookie.rejoin-key}") String rejoinKey) {
+    public RoomMemberCookieEncryptor(EncryptionUtils encryptionUtils, @Value("${cookie.rejoin-key}") String rejoinKey) {
         this.encryptionUtils = encryptionUtils;
         this.rejoinKey = rejoinKey;
     }
 
-    public ResponseCookie getEncodedCookie(Object value) {
+    public ResponseCookie getEncodedCookie(Object value, String requestURI) {
         String encrypt = encryptionUtils.encrypt(String.valueOf(value));
         return ResponseCookie.from(rejoinKey, encrypt)
                 .httpOnly(true)
                 .secure(true)
                 .path(DEFAULT_PATH)
-                .sameSite(SAME_SITE_OPTION)
+                .sameSite(getSameSiteOption(requestURI))
                 .build();
+    }
+
+    private String getSameSiteOption(String uri) {
+        if (uri.equals(LOCALHOST)) {
+            return NONE;
+        }
+        return LAX;
     }
 
     public Long getDecodedCookieValue(String cookieValue) {

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -21,13 +21,13 @@ public class RoomMemberCookieEncryptor {
         this.rejoinKey = rejoinKey;
     }
 
-    public ResponseCookie getEncodedCookie(Object value, String requestURI) {
+    public ResponseCookie getEncodedCookie(Object value, String requestURL) {
         String encrypt = encryptionUtils.encrypt(String.valueOf(value));
         return ResponseCookie.from(rejoinKey, encrypt)
                 .httpOnly(true)
                 .secure(true)
                 .path(DEFAULT_PATH)
-                .sameSite(getSameSiteOption(requestURI))
+                .sameSite(getSameSiteOption(requestURL))
                 .build();
     }
 

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -33,7 +33,7 @@ public class RoomMemberCookieEncryptor {
     }
 
     private String getSameSiteOption(String origin) {
-        if (origin.startsWith(LOCALHOST)) {
+        if (origin != null && origin.startsWith(LOCALHOST)) {
             return NONE;
         }
         return LAX;

--- a/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomMemberCookieEncryptor.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 public class RoomMemberCookieEncryptor {
 

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -8,6 +8,7 @@ import ddangkong.exception.room.NotFinishedRoomException;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinResponse;
+import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
@@ -53,10 +54,10 @@ public class RoomFacade {
     }
 
     @Transactional(readOnly = true)
-    public RoomJoinResponse rejoinRoom(Long memberId) {
+    public RoomMemberResponse getRoomMemberInfo(Long memberId) {
         Member member = memberService.getMemberById(memberId);
         Room room = member.getRoom();
-        return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
+        return new RoomMemberResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 
     @Transactional

--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomMemberResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomMemberResponse.java
@@ -1,0 +1,10 @@
+package ddangkong.facade.room.dto;
+
+import ddangkong.facade.room.member.dto.MemberResponse;
+
+public record RoomMemberResponse(
+        Long roomId,
+        String roomUuid,
+        MemberResponse member
+) {
+}

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -349,7 +349,7 @@ class RoomControllerTest extends BaseControllerTest {
         }
 
         @Test
-        void 쿠키를_통해_방에_재참여_할_수_있다() {
+        void 쿠키를_통해_사용자_정보를_조회_할_수_있다() {
             // given
             RoomJoinRequest body = new RoomJoinRequest("참가자");
             String cookie = RestAssured.given().log().all()
@@ -362,7 +362,7 @@ class RoomControllerTest extends BaseControllerTest {
             RoomJoinResponse roomJoinResponse = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
                     .cookie("test_cookie", cookie)
-                    .when().get("/api/balances/rooms/rejoin")
+                    .when().get("/api/balances/rooms/member")
                     .then().contentType(ContentType.JSON).log().all()
                     .statusCode(200)
                     .extract().as(RoomJoinResponse.class);

--- a/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
@@ -1,0 +1,45 @@
+package ddangkong.controller.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ddangkong.controller.BaseControllerTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseCookie;
+
+class RoomMemberCookieEncryptorTest extends BaseControllerTest {
+
+    @Autowired
+    private RoomMemberCookieEncryptor roomMemberCookieEncryptor;
+
+    @Nested
+    class 방_멤버_쿠키_암호화 {
+        
+        @Test
+        void 로컬_환경인_경우_SameSite는_None_이다() {
+            // given
+            String value = "ThisIsMySecretKe";
+            String uri = "localhost";
+           
+            // when
+            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, uri);
+
+            // then
+            assertThat(encodedCookie.getSameSite()).isEqualTo("None");
+        }
+
+        @Test
+        void 로컬_환경이_아닌_경우_SameSite는_Lax_이다() {
+            // given
+            String value = "ThisIsMySecretKe";
+            String uri = "ddangkong.kr";
+
+            // when
+            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, uri);
+
+            // then
+            assertThat(encodedCookie.getSameSite()).isEqualTo("Lax");
+        }
+    }
+}

--- a/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
@@ -20,7 +20,7 @@ class RoomMemberCookieEncryptorTest extends BaseControllerTest {
         void 로컬_환경인_경우_SameSite는_None_이다() {
             // given
             String value = "ThisIsMySecretKe";
-            String uri = "localhost";
+            String uri = "http://localhost:3306/api";
            
             // when
             ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, uri);

--- a/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomMemberCookieEncryptorTest.java
@@ -20,10 +20,10 @@ class RoomMemberCookieEncryptorTest extends BaseControllerTest {
         void 로컬_환경인_경우_SameSite는_None_이다() {
             // given
             String value = "ThisIsMySecretKe";
-            String uri = "http://localhost:3306/api";
+            String origin = "http://localhost:3306/api";
            
             // when
-            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, uri);
+            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, origin);
 
             // then
             assertThat(encodedCookie.getSameSite()).isEqualTo("None");
@@ -33,10 +33,10 @@ class RoomMemberCookieEncryptorTest extends BaseControllerTest {
         void 로컬_환경이_아닌_경우_SameSite는_Lax_이다() {
             // given
             String value = "ThisIsMySecretKe";
-            String uri = "ddangkong.kr";
+            String origin = "ddangkong.kr";
 
             // when
-            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, uri);
+            ResponseCookie encodedCookie = roomMemberCookieEncryptor.getEncodedCookie(value, origin);
 
             // then
             assertThat(encodedCookie.getSameSite()).isEqualTo("Lax");

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -37,6 +37,7 @@ import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
+import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomSettingResponse;
 import ddangkong.facade.room.dto.RoomStatusResponse;
@@ -218,16 +219,16 @@ class RoomDocumentationTest extends BaseDocumentationTest {
     }
 
     @Nested
-    class 방_재참여 {
+    class 사용자_정보_조회 {
 
-        private static final String ENDPOINT = "/api/balances/rooms/rejoin";
+        private static final String ENDPOINT = "/api/balances/rooms/member";
 
         @Test
-        void 방에_재참여하여_유저_정보를_조회한다() throws Exception {
+        void 사용자_정보를_조회한다() throws Exception {
             // given
-            RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
+            RoomMemberResponse response = new RoomMemberResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
                     new MemberResponse(2L, "타콩", false));
-            when(roomFacade.rejoinRoom(anyLong())).thenReturn(response);
+            when(roomFacade.getRoomMemberInfo(anyLong())).thenReturn(response);
 
             //when & then
             mockMvc.perform(get(ENDPOINT)
@@ -235,7 +236,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                             .cookie(new Cookie("test_cookie", "oNnHwjSR1G4E5L8Mute61w=="))
                     )
                     .andExpect(status().isOk())
-                    .andDo(document("room/rejoin",
+                    .andDo(document("room/member",
                             requestCookies(
                                     cookieWithName("test_cookie").description("사용자 인증에 필요한 쿠키(쿠키의 키 값은 UUID로 예측할 수 없는 값이 들어감)")
                             ),

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -26,7 +26,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ddangkong.controller.room.RejoinCookieEncryptor;
+import ddangkong.controller.room.RoomMemberCookieEncryptor;
 import ddangkong.controller.room.EncryptionUtils;
 import ddangkong.controller.room.RoomController;
 import ddangkong.documentation.BaseDocumentationTest;
@@ -54,7 +54,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
 @WebMvcTest(value = RoomController.class)
-@Import(value = {RejoinCookieEncryptor.class, EncryptionUtils.class})
+@Import(value = {RoomMemberCookieEncryptor.class, EncryptionUtils.class})
 class RoomDocumentationTest extends BaseDocumentationTest {
 
     @MockBean

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -26,6 +26,7 @@ import ddangkong.facade.BaseServiceTest;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinResponse;
+import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
 import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
@@ -126,10 +127,10 @@ class RoomFacadeTest extends BaseServiceTest {
     }
 
     @Nested
-    class 방_재참여 {
+    class 사용자_정보_조회 {
 
         @Test
-        void 이전_방에_재참여한다() {
+        void 사용자_정보를_조회한다() {
             // given
             String nickname = "나는참가자";
             String uuid = "uuid4";
@@ -137,7 +138,7 @@ class RoomFacadeTest extends BaseServiceTest {
             roomFacade.joinRoom(nickname, uuid);
 
             // when
-            RoomJoinResponse actual = roomFacade.rejoinRoom(14L);
+            RoomMemberResponse actual = roomFacade.getRoomMemberInfo(14L);
 
             // then
             assertAll(
@@ -148,12 +149,12 @@ class RoomFacadeTest extends BaseServiceTest {
         }
 
         @Test
-        void 존재하지_않는_아이디로_방에_재참여할_수_없다() {
+        void 존재하지_않는_아이디로_사용자_정보를_조회할_수_없다() {
             // given
             Long notExistMemberId = 0L;
 
             // when & then
-            assertThatThrownBy(() -> roomFacade.rejoinRoom(notExistMemberId))
+            assertThatThrownBy(() -> roomFacade.getRoomMemberInfo(notExistMemberId))
                     .isExactlyInstanceOf(InvalidMemberIdException.class);
         }
     }


### PR DESCRIPTION
## Issue Number
close #357 

## As-Is
<!-- 문제 상황 정의 -->
- 프론트엔드에서 쿠키를 헤더에 담아서 요청을 보내려면 SameSite설정을 변경해야한다.
- 멤버 정보를 조회하는 API가 rejoin이여서 혼란이 옴

## To-Be
<!-- 변경 사항 -->
- SameSite설정을 변경
- rejoin 에서 member 로 URI 변경

## Check List
- [x] 테스트가 전부 통과되었나요? 
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/27bcd464-23eb-49b8-9340-8da11da6cc30)


## (Optional) Additional Description
RoomMemberResponse는 RoomJoinReponse와 필드가 동일하지만 서로 응답하고자 하는바가 다르다고 생각하여 RoomMemberResponse를 추가했습니다.