### PR TITLE
[REFACTOR] 에러 핸들링 공통 로직 개선 및 쿠키 에러 핸들링

### DIFF
--- a/frontend/src/components/GameResult/GameResult.hook.ts
+++ b/frontend/src/components/GameResult/GameResult.hook.ts
@@ -2,15 +2,11 @@ import { useMutation, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
-import AlertModal from '../common/AlertModal/AlertModal';
-
 import { fetchMatchingResult } from '@/apis/balanceContent';
 import { resetRoom } from '@/apis/room';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import useModal from '@/hooks/useModal';
 import { memberInfoState } from '@/recoil/atom';
 import { MatchingResult, MemberMatchingInfo } from '@/types/balanceContent';
-import { CustomError } from '@/utils/error';
 
 type MatchingResultQueryResponse = UseQueryResult<MatchingResult, Error> & {
   matchedMembers?: MemberMatchingInfo[];
@@ -39,12 +35,7 @@ export const useMatchingResultQuery = (): MatchingResultQueryResponse => {
 };
 
 export const useResetRoomMutation = (roomId: number) => {
-  const { show: showModal } = useModal();
-
   return useMutation({
     mutationFn: async () => await resetRoom(roomId),
-    onError: (error: CustomError) => {
-      showModal(AlertModal, { title: '방 초기화 에러', message: error.message });
-    },
   });
 };

--- a/frontend/src/components/StartButtonContainer/StartButton/hooks/useGameStart.ts
+++ b/frontend/src/components/StartButtonContainer/StartButton/hooks/useGameStart.ts
@@ -3,32 +3,14 @@ import { useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import { startGame } from '@/apis/room';
-import AlertModal from '@/components/common/AlertModal/AlertModal';
-import useModal from '@/hooks/useModal';
-import useToast from '@/hooks/useToast';
 import { memberInfoState } from '@/recoil/atom';
-import { CustomError, NetworkError } from '@/utils/error';
-
-const isServerError = (status: number) => status >= 500 && status !== 555;
 
 export const useGameStart = () => {
   const [memberInfo, setMemberInfo] = useRecoilState(memberInfoState);
   const { roomId } = useParams();
-  const { show } = useToast();
-  const { show: showModal } = useModal();
 
   const startGameMutation = useMutation({
     mutationFn: () => startGame(Number(roomId)),
-    onError: (error: CustomError) => {
-      if (error instanceof NetworkError) {
-        show(error.message);
-        return;
-      }
-
-      showModal(AlertModal, { title: '게임 시작 에러', message: error.message });
-    },
-    networkMode: 'always',
-    throwOnError: (error: CustomError) => isServerError(error.status),
   });
 
   const handleGameStart = () => {

--- a/frontend/src/components/TopicContainer/TopicContainer.test.tsx
+++ b/frontend/src/components/TopicContainer/TopicContainer.test.tsx
@@ -10,15 +10,14 @@ import { server } from '@/mocks/server';
 import { customRender } from '@/utils/test-utils';
 
 describe('TopicContainer', () => {
-  const LOADING_DELAY = 300;
-
   it('게임 컨텐츠를 불러올 때 300ms 이상 delay가 걸릴 경우 로딩 UI를 보여준다.', async () => {
+    const LOADING_DELAY = 300;
+    const LOADING_TEXT = '로딩중';
     server.use(
       http.get(MOCK_API_URL.balanceContent, async () => {
         await delay(LOADING_DELAY);
       }),
     );
-    const LOADING_TEXT = '로딩중';
 
     customRender(<TopicContainer />, { pendingFallback: <GameSkeleton /> });
 
@@ -31,7 +30,6 @@ describe('TopicContainer', () => {
     console.error = jest.fn();
     server.use(
       http.get(MOCK_API_URL.balanceContent, async () => {
-        await delay(LOADING_DELAY);
         return HttpResponse.json(
           {
             errorCode: 'NOT_FOUND_BALANCE_CONTENT',

--- a/frontend/src/components/common/ErrorFallback/AsyncErrorFallback/AsyncErrorFallback.tsx
+++ b/frontend/src/components/common/ErrorFallback/AsyncErrorFallback/AsyncErrorFallback.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-
 import Button from '../../Button/Button';
 import {
   errorFallbackLayout,
@@ -17,10 +15,8 @@ interface AsyncErrorFallback {
 }
 
 const AsyncErrorFallback = ({ error, resetError }: AsyncErrorFallback) => {
-  const navigate = useNavigate();
-
   const goToHome = () => {
-    navigate('/');
+    window.location.href = '/';
   };
 
   return (

--- a/frontend/src/components/common/ErrorFallback/RouterErrorFallback/RouterErrorFallback.tsx
+++ b/frontend/src/components/common/ErrorFallback/RouterErrorFallback/RouterErrorFallback.tsx
@@ -1,15 +1,11 @@
-import { useNavigate } from 'react-router-dom';
-
 import Button from '../../Button/Button';
 import { errorFallbackLayout, errorImage, errorText } from '../ErrorFallback.styled';
 
 import ErrorDdangkong from '@/assets/images/errorDdangkong.webp';
 
 const RouterErrorFallback = () => {
-  const navigate = useNavigate();
-
   const goToHome = () => {
-    navigate('/');
+    window.location.href = '/';
   };
 
   return (

--- a/frontend/src/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider.tsx
+++ b/frontend/src/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider.tsx
@@ -1,0 +1,38 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+
+import AlertModal from '../AlertModal/AlertModal';
+
+import useModal from '@/hooks/useModal';
+import useToast from '@/hooks/useToast';
+import { CustomError, NetworkError } from '@/utils/error';
+
+const isServerError = (status: number) => status >= 500 && status !== 555;
+
+const QueryClientDefaultOptionProvider = ({ children }: PropsWithChildren) => {
+  const queryClient = useQueryClient();
+  const { show } = useToast();
+  const { show: showModal } = useModal();
+
+  queryClient.setDefaultOptions({
+    queries: { throwOnError: true },
+    mutations: {
+      onError: (error) => {
+        if (error instanceof NetworkError) {
+          show(error.message);
+          return;
+        }
+        showModal(AlertModal, { title: '에러', message: error.message });
+      },
+      throwOnError: (err) => {
+        const error = err as CustomError;
+        return isServerError(error.status);
+      },
+      networkMode: 'always',
+    },
+  });
+
+  return <>{children}</>;
+};
+
+export default QueryClientDefaultOptionProvider;

--- a/frontend/src/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider.tsx
+++ b/frontend/src/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider.tsx
@@ -9,13 +9,18 @@ import { CustomError, NetworkError } from '@/utils/error';
 
 const isServerError = (status: number) => status >= 500 && status !== 555;
 
+// QueryClient는 모든 Provider에 공유되면서 공통 에러 핸들링 로직에 Toast와 Modal을 넣기 위해 setDefaultOptions 사용
+// 테스트 환경에서 retry 값이 있을 경우 에러 폴백 테스트가 돌지 않아 분기 처리
 const QueryClientDefaultOptionProvider = ({ children }: PropsWithChildren) => {
   const queryClient = useQueryClient();
   const { show } = useToast();
   const { show: showModal } = useModal();
 
   queryClient.setDefaultOptions({
-    queries: { throwOnError: true },
+    queries: {
+      retry: process.env.NODE_ENV === 'test' ? false : 3,
+      throwOnError: true,
+    },
     mutations: {
       onError: (error) => {
         if (error instanceof NetworkError) {

--- a/frontend/src/components/common/SelectButton/SelectButton.hook.ts
+++ b/frontend/src/components/common/SelectButton/SelectButton.hook.ts
@@ -2,15 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
-import AlertModal from '../AlertModal/AlertModal';
-
 import { voteBalanceContent } from '@/apis/balanceContent';
-import useModal from '@/hooks/useModal';
-import useToast from '@/hooks/useToast';
 import { memberInfoState } from '@/recoil/atom';
-import { CustomError, NetworkError } from '@/utils/error';
-
-const isServerError = (status: number) => status >= 500 && status !== 555;
 
 interface UseSelectCompleteMutationProps {
   selectedId: number;
@@ -25,8 +18,6 @@ const useCompleteSelectionMutation = ({
 }: UseSelectCompleteMutationProps) => {
   const { roomId } = useParams();
   const memberInfo = useRecoilValue(memberInfoState);
-  const { show } = useToast();
-  const { show: showModal } = useModal();
 
   return useMutation({
     mutationFn: async () => {
@@ -44,16 +35,6 @@ const useCompleteSelectionMutation = ({
     onSuccess: () => {
       completeSelection();
     },
-    onError: (error: CustomError) => {
-      if (error instanceof NetworkError) {
-        show(error.message);
-        return;
-      }
-
-      showModal(AlertModal, { title: '선택 에러', message: error.message });
-    },
-    networkMode: 'always',
-    throwOnError: (error: CustomError) => isServerError(error.status),
   });
 };
 

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -17,7 +17,7 @@ export const ERROR_MESSAGE: Record<ErrorCode, string> = {
   NOT_EXIST_COMMON: '일반 멤버가 존재하지 않습니다.',
 
   // 방 설정 관련 에러 (roomSetting)
-  INVALID_TIME_LIMIT: '타이머는 5초, 10초, 15초로만 설정 가능합니다.',
+  INVALID_TIME_LIMIT: '타이머는 10초, 15초, 30초, 60초로만 설정 가능합니다.',
   INVALID_RANGE_TOTAL_ROUND: '총 라운드는 5, 7, 10 라운드로만 설정 가능합니다.',
   EMPTY_VOTE_DEADLINE: '라운드 종료 시간이 설정되지 않았습니다.',
 

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -50,4 +50,10 @@ export const ERROR_MESSAGE: Record<ErrorCode, string> = {
 
   // 서버 에러
   INTERNAL_SERVER_ERROR: '서버에 오류가 발생했어요. 다시 시도해 주세요!',
+
+  // 쿠키 관련 에러(권한)
+  NOT_FOUND_COOKIE:
+    '사용자 정보가 있어야 방에 참여할 수 있어요. 홈화면으로 이동하여 방을 새로 만들어주세요!',
+  INVALID_COOKIE:
+    '사용자 정보가 있어야 방에 참여할 수 있어요. 홈화면으로 이동하여 방을 새로 만들어주세요!',
 };

--- a/frontend/src/pages/MainPage/useCreateRoom.ts
+++ b/frontend/src/pages/MainPage/useCreateRoom.ts
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
+import { ROUTES } from '@/constants/routes';
 import { memberInfoState } from '@/recoil/atom';
 
 export const useCreateRoom = () => {
@@ -8,7 +9,7 @@ export const useCreateRoom = () => {
   const setMemberInfo = useSetRecoilState(memberInfoState);
 
   const goToNicknamePage = () => {
-    navigate('/nickname');
+    navigate(ROUTES.nickname);
   };
 
   const handleRoomCreate = () => {

--- a/frontend/src/pages/NicknamePage/useMakeOrEnterRoom.ts
+++ b/frontend/src/pages/NicknamePage/useMakeOrEnterRoom.ts
@@ -4,9 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import { enterRoom, createRoom } from '@/apis/room';
-import AlertModal from '@/components/common/AlertModal/AlertModal';
 import { ROUTES } from '@/constants/routes';
-import useModal from '@/hooks/useModal';
 import { memberInfoState, roomUuidState } from '@/recoil/atom';
 import { CreateOrEnterRoomResponse } from '@/types/room';
 import { CustomError } from '@/utils/error';
@@ -18,7 +16,6 @@ const useMakeOrEnterRoom = () => {
 
   const [, setRoomUuidState] = useRecoilState(roomUuidState);
   const { roomUuid } = useParams();
-  const { show: showModal } = useModal();
 
   const createRoomMutation = useMutation<CreateOrEnterRoomResponse, CustomError, string>({
     mutationFn: createRoom,
@@ -29,9 +26,6 @@ const useMakeOrEnterRoom = () => {
       }));
       setRoomUuidState(data.roomUuid || '');
       navigate(ROUTES.ready(Number(data.roomId)), { replace: true });
-    },
-    onError: (error) => {
-      showModal(AlertModal, { title: '방 생성 에러', message: error.message });
     },
   });
 
@@ -45,9 +39,6 @@ const useMakeOrEnterRoom = () => {
       setMemberInfo((prev) => ({ ...prev, memberId: data.member.memberId }));
       setRoomUuidState(data.roomUuid || '');
       navigate(ROUTES.ready(Number(data.roomId)), { replace: true });
-    },
-    onError: (error: CustomError) => {
-      showModal(AlertModal, { title: '방 참여 에러', message: error.message });
     },
   });
 

--- a/frontend/src/router/HeaderLayout.tsx
+++ b/frontend/src/router/HeaderLayout.tsx
@@ -1,8 +1,37 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
 
+import AlertModal from '@/components/common/AlertModal/AlertModal';
 import Header from '@/components/layout/Header/Header';
+import useModal from '@/hooks/useModal';
+import useToast from '@/hooks/useToast';
+import { CustomError, NetworkError } from '@/utils/error';
+
+const isServerError = (status: number) => status >= 500 && status !== 555;
 
 const HeaderLayout = () => {
+  const queryClient = useQueryClient();
+  const { show } = useToast();
+  const { show: showModal } = useModal();
+
+  queryClient.setDefaultOptions({
+    queries: { throwOnError: true },
+    mutations: {
+      onError: (error) => {
+        if (error instanceof NetworkError) {
+          show(error.message);
+          return;
+        }
+        showModal(AlertModal, { title: '에러', message: error.message });
+      },
+      throwOnError: (err) => {
+        const error = err as CustomError;
+        return isServerError(error.status);
+      },
+      networkMode: 'always',
+    },
+  });
+
   return (
     <>
       <Header />

--- a/frontend/src/router/HeaderLayout.tsx
+++ b/frontend/src/router/HeaderLayout.tsx
@@ -1,42 +1,14 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
 
-import AlertModal from '@/components/common/AlertModal/AlertModal';
+import QueryClientDefaultOptionProvider from '@/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider';
 import Header from '@/components/layout/Header/Header';
-import useModal from '@/hooks/useModal';
-import useToast from '@/hooks/useToast';
-import { CustomError, NetworkError } from '@/utils/error';
-
-const isServerError = (status: number) => status >= 500 && status !== 555;
 
 const HeaderLayout = () => {
-  const queryClient = useQueryClient();
-  const { show } = useToast();
-  const { show: showModal } = useModal();
-
-  queryClient.setDefaultOptions({
-    queries: { throwOnError: true },
-    mutations: {
-      onError: (error) => {
-        if (error instanceof NetworkError) {
-          show(error.message);
-          return;
-        }
-        showModal(AlertModal, { title: '에러', message: error.message });
-      },
-      throwOnError: (err) => {
-        const error = err as CustomError;
-        return isServerError(error.status);
-      },
-      networkMode: 'always',
-    },
-  });
-
   return (
-    <>
+    <QueryClientDefaultOptionProvider>
       <Header />
       <Outlet />
-    </>
+    </QueryClientDefaultOptionProvider>
   );
 };
 

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -31,14 +31,6 @@ export const router = createBrowserRouter([
         element: <HeaderLayout />,
         children: [
           {
-            path: ':roomId/game',
-            element: (
-              <AsyncErrorBoundary pendingFallback={<GameSkeleton />}>
-                <GamePage />
-              </AsyncErrorBoundary>
-            ),
-          },
-          {
             path: 'nickname/:roomUuid?',
             element: (
               <AsyncErrorBoundary>
@@ -51,6 +43,14 @@ export const router = createBrowserRouter([
             element: (
               <AsyncErrorBoundary pendingFallback={<ReadySkeleton />}>
                 <ReadyPage />
+              </AsyncErrorBoundary>
+            ),
+          },
+          {
+            path: ':roomId/game',
+            element: (
+              <AsyncErrorBoundary pendingFallback={<GameSkeleton />}>
+                <GamePage />
               </AsyncErrorBoundary>
             ),
           },

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -29,7 +29,9 @@ export type ErrorCode =
   | 'METHOD_ARGUMENT_TYPE_MISMATCH'
   | 'NO_RESOURCE_FOUND'
   | 'METHOD_NOT_SUPPORTED'
-  | 'INTERNAL_SERVER_ERROR';
+  | 'INTERNAL_SERVER_ERROR'
+  | 'NOT_FOUND_COOKIE'
+  | 'INVALID_COOKIE';
 
 export interface UrlParameterError extends ResponseError {
   errorCode: 'URL_PARAMETER_ERROR';

--- a/frontend/src/utils/test-utils.tsx
+++ b/frontend/src/utils/test-utils.tsx
@@ -9,6 +9,7 @@ import type { MutableSnapshot } from 'recoil';
 
 import AsyncErrorBoundary from '@/components/common/ErrorBoundary/AsyncErrorBoundary';
 import RootErrorBoundary from '@/components/common/ErrorBoundary/RootErrorBoundary';
+import QueryClientDefaultOptionProvider from '@/components/common/QueryClientDefaultOptionProvider/QueryClientDefaultOptionProvider';
 import Spinner from '@/components/common/Spinner/Spinner';
 import ModalProvider from '@/providers/ModalProvider/ModalProvider';
 import ToastProvider from '@/providers/ToastProvider/ToastProvider';
@@ -38,13 +39,15 @@ const wrapper = ({
         <ThemeProvider theme={Theme}>
           <Global styles={GlobalStyle} />
           <ToastProvider>
-            <MemoryRouter initialEntries={['/']}>
-              <RootErrorBoundary>
-                <AsyncErrorBoundary pendingFallback={pendingFallback}>
-                  <ModalProvider>{children}</ModalProvider>
-                </AsyncErrorBoundary>
-              </RootErrorBoundary>
-            </MemoryRouter>
+            <RootErrorBoundary>
+              <AsyncErrorBoundary pendingFallback={pendingFallback}>
+                <MemoryRouter initialEntries={['/']}>
+                  <ModalProvider>
+                    <QueryClientDefaultOptionProvider>{children}</QueryClientDefaultOptionProvider>
+                  </ModalProvider>
+                </MemoryRouter>
+              </AsyncErrorBoundary>
+            </RootErrorBoundary>
           </ToastProvider>
         </ThemeProvider>
       </RecoilRoot>


### PR DESCRIPTION
## Issue Number
#358 

## As-Is
<!-- 문제 상황 정의 -->
- 똑같은 에러 핸들링 로직인데 중복해서 사용하고 있었음
- 다른 mutation에 대해서도 같은 에러 처리인데 처리되지 않고 있었음
- 쿠키 로직이 추가되면서 쿠키 관련 에러 핸들링이 안되고 있었음

## To-Be
<!-- 변경 사항 -->
- 공통 에러 핸들링 로직을 setDefaultOptions를 이용해 queryClient에서 처리
- 쿠키 에러 코드 및 에러 메시지 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

### 공통 에러 핸들링 (setDefaultOptions)

queryClient 에서 똑같은 로직으로 처리되는 에러 핸들링 로직들을 묶었습니다.
가장 어려웠던 부분은 Modal 에서도 QueryClient가 필요하고, QueryClient 에서도 Modal 이 필요한 모순적인 상황이였습니다.
방설정 모달에서 invalidateQueries를 하기 위해 QueryClient가 부모에 있어야 하고, QueryClient에서 공통 에러 핸들링 로직을 묶기 위해 Modal이 부모에 있어야 했습니다.

이러한 문제를 그려봤을 때 QueryClient는 무조건 Modal보다 부모에 있어야 한다고 판단했고, Modal 하위에서 공통 에러 핸들링 로직을 묶는 방법을 찾아봤습니다.
Tkdodo님 블로그를 봤을 땐 QueryCache를 사용하여 공통 로직을 분리하는 것을 권장했는데, QueryCache는 QueryClient를 생성할 때만 주입할 수 있어서 `setDefaultOptions` 로 처리하였습니다.

### 테스트에 리팩토링 적용 시 errorFallback 테스트 오류
또한 테스트 케이스에서 억까(?)를 당했는데 retry가 false가 아닐 경우 에러 폴백이 안뜨는 문제가 있었습니다. 해당 문제는 기존 옵션이 덮어씌워지면서 문제가 발생했다는 걸 알게 되었습니다!!!!
하지만 프로덕션 환경에서까지 retry를 없애는 건 별로 안좋다 생각해서 테스트 환경과 분기처리하였습니다.

<img src="https://github.com/user-attachments/assets/71998a33-c130-4929-9ef4-7bcfc7c4e3db" width="600" />


### 요약

1. 공통으로 묶어서 에러 처리를 할 수 있는데, QueryClient에서 해야한다.
2. 공통 에러 처리에 Toast와 Modal을 사용한다.
3. 사용하려면 Toast와 Modal이 QueryClient 보다 부모에 위치해야 한다.
4. 하지만 Modal에서도 useQueryClient를 사용하기 때문에 QueryClient가 Modal보다 부모에 있어야 한다.
5. 4번이 성립하기 위해선 무조건 ModalProvider 위에 QueryClient가 있어야 한다.
6. 따라서 ToastProvider -> QueryClient -> ModalProvider 상태로 두고, QueryClient 공통 에러 처리 로직을 ModalProvider 하위에서 처리할 것이다.
7. 6번 방식을 가능하게 하는 함수 ->  `queryClient.setDefaultOptions`

## (Optional) Additional Description

### 쿠키 에러 메시지

쿠키 에러 발생 시 에러 메시지는 토스 블로그를 참고하였습니다. 초점을 맞춘건 부정적으로 말하지 않기, 쉽게 해결할 수 있게 도와주기 입니다!

https://toss.tech/article/how-to-write-error-message
https://toss.tech/article/21022
