### PR TITLE
[FIX] 모바일 방 설정 컴포넌트 화면 깨짐 해결 

### DIFF
--- a/frontend/src/components/RoomSetting/RoomSetting.styled.ts
+++ b/frontend/src/components/RoomSetting/RoomSetting.styled.ts
@@ -6,7 +6,7 @@ import getBorderRadius from '@/styles/utils/getBorderRadius';
 export const roomSettingLayout = css`
   display: flex;
   flex-direction: column;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-items: center;
   width: 100%;
   height: 10rem;
@@ -38,7 +38,7 @@ export const roomSettingKey = css`
 export const roomSettingKeyBox = css`
   display: flex;
   justify-content: space-between;
-  width: 50rem;
+  width: 80%;
 
   font-weight: 600;
 `;
@@ -47,5 +47,5 @@ export const roomSettingValueBox = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 50rem;
+  width: 80%;
 `;


### PR DESCRIPTION
## Issue Number

#375

## As-Is
모바일 방 설정 컴포넌트 화면 깨지고 있음 

## To-Be
모바일 방 설정 컴포넌트 화면 깨지지 않게 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

- 개선 전 
![image](https://github.com/user-attachments/assets/4da6a595-a2d5-4e2a-87d5-5063813600a4)

- 개선 후 
![image](https://github.com/user-attachments/assets/0baf5102-0032-466e-87d8-a45347b8596f)


## (Optional) Additional Description
