### PR TITLE
[REFACTOR] Nickname 검증 규칙 수정

### DIFF
--- a/backend/src/main/java/ddangkong/domain/room/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/room/member/Member.java
@@ -15,13 +15,13 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
 
-    private static final int NICKNAME_MIN_LENGTH = 2;
     private static final int NICKNAME_MAX_LENGTH = 12;
 
     @Id
@@ -46,8 +46,8 @@ public class Member {
     }
 
     private void validateNickname(String nickname) {
-        if (nickname.length() < NICKNAME_MIN_LENGTH || nickname.length() > NICKNAME_MAX_LENGTH) {
-            throw new InvalidNicknameException(NICKNAME_MIN_LENGTH, NICKNAME_MAX_LENGTH);
+        if (Strings.isBlank(nickname) || nickname.length() > NICKNAME_MAX_LENGTH) {
+            throw new InvalidNicknameException(NICKNAME_MAX_LENGTH);
         }
     }
 

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -35,7 +35,7 @@ public enum ClientErrorCode {
     NOT_EXIST_COMMON("일반 멤버가 존재하지 않습니다."),
     EXCEED_MAX_MEMBER_COUNT("방의 최대 인원을 초과했습니다. 현재 멤버 수: %d"),
     NOT_ROOM_MEMBER("방에 존재하지 않는 멤버입니다."),
-    INVALID_NICKNAME("닉네임은 최소 %d글자, 최대 %d글자여야 합니다."),
+    INVALID_NICKNAME("닉네임은 공백이어선 안되며 최대 %d글자여야 합니다."),
     INVALID_MEMBER_ID("해당 ID에 일치하는 멤버가 없습니다."),
 
     // RoomContent

--- a/backend/src/main/java/ddangkong/exception/room/member/InvalidNicknameException.java
+++ b/backend/src/main/java/ddangkong/exception/room/member/InvalidNicknameException.java
@@ -6,8 +6,8 @@ import ddangkong.exception.BadRequestException;
 
 public class InvalidNicknameException extends BadRequestException {
 
-    public InvalidNicknameException(int minLength, int maxLength) {
-        super(INVALID_NICKNAME.getMessage().formatted(minLength, maxLength));
+    public InvalidNicknameException(int maxLength) {
+        super(INVALID_NICKNAME.getMessage().formatted(maxLength));
     }
 
     @Override

--- a/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
@@ -66,7 +66,7 @@ class MemberTest {
             assertThat(actual).isFalse();
         }
     }
-    
+
     @Nested
     class 닉네임_검증 {
 
@@ -78,7 +78,7 @@ class MemberTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"0", "", "0123456789123"})
+        @ValueSource(strings = {" ", "", "0123456789123"})
         void 닉네임_길이가_유효하지_않는_경우_예외를_발생시킨다(String name) {
             // when & then
             assertThatThrownBy(() -> Member.createMaster(name, ROOM))


### PR DESCRIPTION
## Issue Number
#383 

## As-Is
<!-- 문제 상황 정의 -->
닉네임 길이 검증을 1자부터 12자로 설정해야한다.
이때 Null, Blank 등에 대한 제한도 함께 수행하도록 검증로직을 변경해야한다.

## To-Be
<!-- 변경 사항 -->
- 닉네임 정책 `2~12자` -> `1~12자` 로 변경
- 공백, Null 제한 설정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="846" alt="스크린샷 2024-10-24 21 16 04" src="https://github.com/user-attachments/assets/0c232046-dfdc-4bf0-a203-ad1dc939842a">


## (Optional) Additional Description
