### PR TITLE
[REFACTOR] Polling에서 사용하지 않는 바디 정보 제거

### DIFF
--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -144,7 +144,6 @@ public class RoomFacade {
     @Transactional(readOnly = true)
     public InitialRoomResponse isInitialRoom(Long roomId) {
         Room room = roomService.getRoom(roomId);
-        Member master = memberService.getMaster(room);
-        return new InitialRoomResponse(room.isInitialRoom(), master);
+        return new InitialRoomResponse(room.isInitialRoom());
     }
 }

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -109,8 +109,7 @@ public class RoomFacade {
     @Transactional(readOnly = true)
     public RoundFinishedResponse getRoundFinished(Long roomId, int round) {
         Room room = roomService.getRoom(roomId);
-        Member master = memberService.getMaster(room);
-        return new RoundFinishedResponse(room.isRoundFinished(round), room.isAllRoundFinished(), master);
+        return new RoundFinishedResponse(room.isRoundFinished(round), room.isAllRoundFinished());
     }
 
     @Transactional

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacade.java
@@ -113,8 +113,7 @@ public class RoomBalanceVoteFacade {
     @Transactional(readOnly = true)
     public VoteFinishedResponse getVoteFinished(Long roomId, Long contentId) {
         VoteContext voteContext = getVoteContext(roomId, contentId);
-        Member master = voteContext.getMaster();
-        return new VoteFinishedResponse(voteContext.isVoteFinished(), master);
+        return new VoteFinishedResponse(voteContext.isVoteFinished());
     }
 
     private VoteContext getVoteContext(Long roomId, Long contentId) {

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/context/VoteContext.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/context/VoteContext.java
@@ -20,10 +20,6 @@ public class VoteContext {
         this.voteFinished = voteFinished;
     }
 
-    public Member getMaster() {
-        return roomMembers.getMaster();
-    }
-
     public Member getMember(Long memberId) {
         return roomMembers.getMember(memberId);
     }

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/VoteFinishedResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/VoteFinishedResponse.java
@@ -1,14 +1,6 @@
 package ddangkong.facade.room.balance.roomvote.dto;
 
-import ddangkong.domain.room.member.Member;
-import ddangkong.facade.room.member.dto.MasterResponse;
-
 public record VoteFinishedResponse(
-        boolean isFinished,
-        MasterResponse master
+        boolean isFinished
 ) {
-
-    public VoteFinishedResponse(boolean isFinished, Member master) {
-        this(isFinished, new MasterResponse(master));
-    }
 }

--- a/backend/src/main/java/ddangkong/facade/room/dto/InitialRoomResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/InitialRoomResponse.java
@@ -1,14 +1,6 @@
 package ddangkong.facade.room.dto;
 
-import ddangkong.domain.room.member.Member;
-import ddangkong.facade.room.member.dto.MasterResponse;
-
 public record InitialRoomResponse(
-        boolean isInitial,
-        MasterResponse master
+        boolean isInitial
 ) {
-
-    public InitialRoomResponse(boolean isInitialRoom, Member master) {
-        this(isInitialRoom, new MasterResponse(master));
-    }
 }

--- a/backend/src/main/java/ddangkong/facade/room/dto/RoundFinishedResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoundFinishedResponse.java
@@ -1,15 +1,7 @@
 package ddangkong.facade.room.dto;
 
-import ddangkong.domain.room.member.Member;
-import ddangkong.facade.room.member.dto.MasterResponse;
-
 public record RoundFinishedResponse(
         boolean isRoundFinished,
-        boolean isGameFinished,
-        MasterResponse master
+        boolean isGameFinished
 ) {
-
-    public RoundFinishedResponse(boolean isRoundFinished, boolean isGameFinished, Member master) {
-        this(isRoundFinished, isGameFinished, new MasterResponse(master));
-    }
 }

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -1,7 +1,6 @@
 package ddangkong.controller.room;
 
 import static ddangkong.support.fixture.MemberFixture.PRIN;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -12,7 +11,6 @@ import ddangkong.domain.room.Room;
 import ddangkong.domain.room.RoomSetting;
 import ddangkong.domain.room.RoomStatus;
 import ddangkong.domain.room.balance.roomcontent.RoomContent;
-import ddangkong.domain.room.member.Member;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
@@ -269,14 +267,13 @@ class RoomControllerTest extends BaseControllerTest {
     class 방_초기화 {
 
         private Room room;
-        private Member master;
 
         @BeforeEach
         void setUp() {
             BalanceContent content = balanceContentRepository.save(new BalanceContent(Category.IF, "A vs B"));
             RoomSetting roomSetting = new RoomSetting(3, 10_000, Category.IF);
             room = roomRepository.save(new Room("roomResetSetUpUUID", 3, RoomStatus.FINISH, roomSetting));
-            master = memberRepository.save(PRIN.master(room));
+            memberRepository.save(PRIN.master(room));
             roomContentRepository.save(new RoomContent(room, content, 1, null));
             roomContentRepository.save(new RoomContent(room, content, 2, null));
             roomContentRepository.save(new RoomContent(room, content, 3, null));
@@ -307,10 +304,7 @@ class RoomControllerTest extends BaseControllerTest {
                     .as(InitialRoomResponse.class);
 
             // then
-            assertAll(
-                    () -> assertThat(actual.isInitial()).isTrue(),
-                    () -> assertThat(actual.master().memberId()).isEqualTo(master.getId())
-            );
+            assertThat(actual.isInitial()).isTrue();
         }
     }
 

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -328,8 +328,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         @Test
         void 라운드가_종료되었는지_조회한다() throws Exception {
             // given
-            MasterResponse prin = new MasterResponse(1L, "프콩");
-            RoundFinishedResponse response = new RoundFinishedResponse(true, false, prin);
+            RoundFinishedResponse response = new RoundFinishedResponse(true, false);
             when(roomFacade.getRoundFinished(anyLong(), anyInt())).thenReturn(response);
 
             // when & then
@@ -346,10 +345,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                             ),
                             responseFields(
                                     fieldWithPath("isRoundFinished").description("라운드 종료 여부"),
-                                    fieldWithPath("isGameFinished").description("게임 종료 여부"),
-                                    fieldWithPath("master").type(OBJECT).description("방장 정보"),
-                                    fieldWithPath("master.memberId").type(NUMBER).description("멤버 ID"),
-                                    fieldWithPath("master.nickname").type(STRING).description("닉네임")
+                                    fieldWithPath("isGameFinished").description("게임 종료 여부")
                             )
                     ));
         }

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -398,8 +398,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         void 방이_초기화되었는지_확인한다() throws Exception {
             // given
             String endpoint = "/api/balances/rooms/{roomId}/initial";
-            MasterResponse prin = new MasterResponse(1L, "프콩");
-            InitialRoomResponse response = new InitialRoomResponse(true, prin);
+            InitialRoomResponse response = new InitialRoomResponse(true);
             when(roomFacade.isInitialRoom(anyLong())).thenReturn(response);
 
             // when & then
@@ -410,10 +409,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     parameterWithName("roomId").description("방 ID")
                             ),
                             responseFields(
-                                    fieldWithPath("isInitial").description("방 초기화 여부"),
-                                    fieldWithPath("master").type(OBJECT).description("방장 정보"),
-                                    fieldWithPath("master.memberId").type(NUMBER).description("멤버 ID"),
-                                    fieldWithPath("master.nickname").type(STRING).description("닉네임")
+                                    fieldWithPath("isInitial").description("방 초기화 여부")
                             )
                     ));
 

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
@@ -31,7 +31,6 @@ import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResultResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMemberVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMembersVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.VoteFinishedResponse;
-import ddangkong.facade.room.member.dto.MasterResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -167,8 +166,7 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
         @Test
         void 투표가_종료되었는지_조회한다() throws Exception {
             // given
-            MasterResponse prin = new MasterResponse(1L, "프콩");
-            VoteFinishedResponse response = new VoteFinishedResponse(true, prin);
+            VoteFinishedResponse response = new VoteFinishedResponse(true);
             when(roomBalanceVoteFacade.getVoteFinished(anyLong(), anyLong())).thenReturn(response);
 
             // when & then
@@ -180,10 +178,7 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             parameterWithName("contentId").description("콘텐츠 ID")
                                     ),
                                     responseFields(
-                                            fieldWithPath("isFinished").type(BOOLEAN).description("투표 종료 여부"),
-                                            fieldWithPath("master").type(OBJECT).description("방장 정보"),
-                                            fieldWithPath("master.memberId").type(NUMBER).description("멤버 ID"),
-                                            fieldWithPath("master.nickname").type(STRING).description("닉네임")
+                                            fieldWithPath("isFinished").type(BOOLEAN).description("투표 종료 여부")
                                     )
                             )
                     );

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -547,16 +547,12 @@ class RoomFacadeTest extends BaseServiceTest {
         void 초기화된_방인지_확인한다() {
             // given
             Room room = roomRepository.save(new Room("uuid", 5, RoomStatus.READY, ROOM_SETTING));
-            Member master = memberRepository.save(PRIN.master(room));
 
             // when
             InitialRoomResponse actual = roomFacade.isInitialRoom(room.getId());
 
             // then
-            assertAll(
-                    () -> assertThat(actual.isInitial()).isFalse(),
-                    () -> assertThat(actual.master().memberId()).isEqualTo(master.getId())
-            );
+            assertThat(actual.isInitial()).isFalse();
         }
     }
 

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -382,7 +382,6 @@ class RoomFacadeTest extends BaseServiceTest {
             int currentRound = 2;
             RoomSetting roomSetting = new RoomSetting(TOTAL_ROUND, TIME_LIMIT, CATEGORY);
             Room room = roomRepository.save(new Room("uuid", currentRound, STATUS, roomSetting));
-            Member master = memberRepository.save(PRIN.master(room));
             int round = 2;
 
             // when
@@ -391,8 +390,7 @@ class RoomFacadeTest extends BaseServiceTest {
             // then
             assertAll(
                     () -> assertThat(roundFinishedResponse.isRoundFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.master().memberId()).isEqualTo(master.getId())
+                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse()
             );
         }
 
@@ -402,7 +400,6 @@ class RoomFacadeTest extends BaseServiceTest {
             int currentRound = 2;
             RoomSetting roomSetting = new RoomSetting(TOTAL_ROUND, TIME_LIMIT, CATEGORY);
             Room room = roomRepository.save(new Room("uuid", currentRound, STATUS, roomSetting));
-            Member master = memberRepository.save(PRIN.master(room));
             int round = 1;
 
             // when
@@ -411,8 +408,7 @@ class RoomFacadeTest extends BaseServiceTest {
             // then
             assertAll(
                     () -> assertThat(roundFinishedResponse.isRoundFinished()).isTrue(),
-                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.master().memberId()).isEqualTo(master.getId())
+                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse()
             );
         }
 
@@ -423,7 +419,6 @@ class RoomFacadeTest extends BaseServiceTest {
             RoomStatus status = RoomStatus.FINISH;
             RoomSetting roomSetting = new RoomSetting(TOTAL_ROUND, TIME_LIMIT, CATEGORY);
             Room room = roomRepository.save(new Room("uuid", currentRound, status, roomSetting));
-            Member master = memberRepository.save(PRIN.master(room));
             int round = 5;
 
             // when
@@ -432,8 +427,7 @@ class RoomFacadeTest extends BaseServiceTest {
             // then
             assertAll(
                     () -> assertThat(roundFinishedResponse.isRoundFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.isGameFinished()).isTrue(),
-                    () -> assertThat(roundFinishedResponse.master().memberId()).isEqualTo(master.getId())
+                    () -> assertThat(roundFinishedResponse.isGameFinished()).isTrue()
             );
         }
 
@@ -452,8 +446,7 @@ class RoomFacadeTest extends BaseServiceTest {
             // then
             assertAll(
                     () -> assertThat(roundFinishedResponse.isRoundFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse(),
-                    () -> assertThat(roundFinishedResponse.master().memberId()).isEqualTo(master.getId())
+                    () -> assertThat(roundFinishedResponse.isGameFinished()).isFalse()
             );
         }
     }

--- a/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
@@ -200,10 +200,7 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
             VoteFinishedResponse actual = roomBalanceVoteFacade.getVoteFinished(room.getId(), content.getId());
 
             // then
-            assertAll(
-                    () -> assertThat(actual.isFinished()).isTrue(),
-                    () -> assertThat(actual.master().memberId()).isEqualTo(prin.getId())
-            );
+            assertThat(actual.isFinished()).isTrue();
         }
 
         @Test
@@ -218,10 +215,7 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
             VoteFinishedResponse actual = roomBalanceVoteFacade.getVoteFinished(room.getId(), content.getId());
 
             // then
-            assertAll(
-                    () -> assertThat(actual.isFinished()).isTrue(),
-                    () -> assertThat(actual.master().memberId()).isEqualTo(prin.getId())
-            );
+            assertThat(actual.isFinished()).isTrue();
         }
 
         @Test
@@ -237,10 +231,7 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
             VoteFinishedResponse actual = roomBalanceVoteFacade.getVoteFinished(room.getId(), content.getId());
 
             // then
-            assertAll(
-                    () -> assertThat(actual.isFinished()).isFalse(),
-                    () -> assertThat(actual.master().memberId()).isEqualTo(prin.getId())
-            );
+            assertThat(actual.isFinished()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
## Issue Number

Closed #394 

## As-Is
<!-- 문제 상황 정의 -->

- 현재 모든 폴링 요청에서 "현재 방의 마스터 정보"를 제공해 주고 있었음
  - 이전 버전에서 "방장 뷰"와 "일반 참여자 뷰"를 구분하기 위한 정보로 사용
- 더 이상 해당 정보가 (방 정보 조회를 제외한) Polling 요청에서 필요하지 않음
  - 현 버전에서는 "내 정보 조회 API"의 캐싱을 사용하여 자신의 정보를 조회함
- 해당 정보는 코드 및 쿼리 등에서 리소스를 잡아 먹기 때문에 제거 필요

## To-Be
<!-- 변경 사항 -->

- (방 정보 조회를 제외한) Polling 요청에서 마스터 정보 제거
  - 라운드 종료 조회 API
  - 투표 종료 조회 API
  - 방 초기화 조회 API

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/34c18432-f9bf-4cb4-8eb1-5aa2f38e259a)


## (Optional) Additional Description
- 관련 회의 자료
  - 부수적으로 다루었습니다~
  - https://www.notion.so/ghenmaru/TF-6e4d7119b7214ee0aec998d474147b61