### PR TITLE
[TEST] 방과 연관된 정보 삭제 테스트 활성화

### DIFF
--- a/backend/src/test/java/ddangkong/domain/support/EntityTestUtils.java
+++ b/backend/src/test/java/ddangkong/domain/support/EntityTestUtils.java
@@ -1,6 +1,5 @@
 package ddangkong.domain.support;
 
-import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class EntityTestUtils {
@@ -10,9 +9,5 @@ public class EntityTestUtils {
 
     public static <T> void setId(T entity, Long id) {
         ReflectionTestUtils.setField(entity, "id", id);
-    }
-
-    public static <T> void setLastModifiedAt(T entity, LocalDateTime lastModifiedAt) {
-        ReflectionTestUtils.setField(entity, "lastModifiedAt", lastModifiedAt);
     }
 }

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -18,7 +18,6 @@ import ddangkong.domain.room.RoomStatus;
 import ddangkong.domain.room.balance.roomcontent.RoomContent;
 import ddangkong.domain.room.balance.roomvote.RoomBalanceVote;
 import ddangkong.domain.room.member.Member;
-import ddangkong.domain.support.EntityTestUtils;
 import ddangkong.exception.room.NotFinishedRoomException;
 import ddangkong.exception.room.NotFoundRoomException;
 import ddangkong.exception.room.member.InvalidMemberIdException;
@@ -35,7 +34,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -585,12 +583,9 @@ class RoomFacadeTest extends BaseServiceTest {
         }
 
         @Test
-        @Disabled
-            // TODO @LastModifiedDate 비활성화 후 테스트
         void 해당_방과_연관된_모든_정보를_삭제할_수_있다() {
             // given
-            LocalDateTime standardModified = LocalDateTime.of(2020, 1, 1, 0, 0, 0);
-            Room room = getSavedRoom(standardModified.minusSeconds(1));
+            Room room = getSavedRoom();
             Member master = memberRepository.save(EDEN.master(room));
             Member common = memberRepository.save(KEOCHAN.common(room));
 
@@ -598,6 +593,7 @@ class RoomFacadeTest extends BaseServiceTest {
             RoomContent roomContent = getSavedRoomContent(room, balanceContent);
             RoomBalanceVote roomVote = getSavedRoomBalanceVote(master, balanceContent);
             long countOfTotalVotes = totalBalanceVoteRepository.count();
+            LocalDateTime standardModified = LocalDateTime.now();
 
             // when
             roomFacade.migrateExpiredRooms(standardModified);
@@ -613,13 +609,13 @@ class RoomFacadeTest extends BaseServiceTest {
                     () -> assertThat(deletedMember).isEmpty(),
                     () -> assertThat(deletedRoomContent).isEmpty(),
                     () -> assertThat(deletedRoomVote).isEmpty(),
-                    () -> assertThat(afterCountOfTotalVotes).isEqualTo(countOfTotalVotes + 1)
+                    () -> assertThat(afterCountOfTotalVotes).isGreaterThanOrEqualTo(countOfTotalVotes + 1)
+                    // TODO init.sql 제거 후 isEqualTo로 변경 (현재 다른 방들의 표까지 이관되어 1표 이상으로 더 늘어남)
             );
         }
 
-        private Room getSavedRoom(LocalDateTime lastModifiedAt) {
+        private Room getSavedRoom() {
             Room room = Room.createNewRoom();
-            EntityTestUtils.setLastModifiedAt(room, lastModifiedAt);
             return roomRepository.save(room);
         }
 


### PR DESCRIPTION
## Issue Number

Closed #397 

## As-Is
<!-- 문제 상황 정의 -->
- `@LastModifiedDate` 문제로 비활성화 되어 있는 테스트 존재
- 이를 수정하여 해당 기능이 정상 작동하는지 확인할 수 있도록 테스트 활성화 필요

## To-Be
<!-- 변경 사항 -->
- `변경_시간이_특정_시각_이전_방_삭제.해당_방과_연관된_모든_정보를_삭제할_수_있다` 테스트 수정
  - 특정 시간 이후에 방 정보들이 삭제하는지 확인하는 테스트
  - 방 생성 후에, 특정 시간을 `LocalDateTime.now()`로 이용해서 설정 -> '특정 시간'을 방 생성 시간 이후로 설정 함

- `init.sql`에 이미 저장되어 있는 방까지 같이 삭제되어 옮긴 투표 수가 1개 초과로 늘어남
  - 추후 작업에서 `init.sql` 삭제 시, `isGreaterThanOrEqualTo`를 `isEqualTo`로 변경 필요

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

![image](https://github.com/user-attachments/assets/397823ad-aee1-4ea6-8087-ee8e8806b8f9)

## (Optional) Additional Description
