### PR TITLE
[REFACTOR] 탭 전환 시 발생하는 타이머 오차를 Web Worker를 활용하여 사용자 경험 개선

### DIFF
--- a/frontend/jest.config.json
+++ b/frontend/jest.config.json
@@ -12,7 +12,7 @@
     "\\.[jt]sx?$": "@swc/jest",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/mocks/fileMock.js"
   },
-  "setupFiles": ["./jest.polyfills.js"],
+  "setupFiles": ["./jest.polyfills.js", "./src/mocks/worker.js"],
   "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"],
   "clearMocks": true
 }

--- a/frontend/src/mocks/worker.js
+++ b/frontend/src/mocks/worker.js
@@ -1,0 +1,15 @@
+export default class TimerWorker {
+  constructor(stringUrl) {
+    this.url = stringUrl;
+    this.onmessage = () => {};
+  }
+
+  postMessage(message) {
+    this.onmessage(message);
+  }
+
+  terminate() {}
+}
+
+// Jest 환경에서 Web Worker를 Mock으로 대체
+window.Worker = TimerWorker;

--- a/frontend/src/pages/GamePage/components/SelectContainer/Timer/Timer.test.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/Timer/Timer.test.tsx
@@ -1,6 +1,3 @@
-import { act, renderHook } from '@testing-library/react';
-
-import useTimer from './hooks/useTimer';
 import { convertMsecToSecond, formatLeftRoundTime } from './Timer.util';
 
 describe('Timer 테스트', () => {
@@ -15,58 +12,6 @@ describe('Timer 테스트', () => {
       const convertedTime = convertMsecToSecond(10000);
 
       expect(convertedTime).toBe(10);
-    });
-  });
-  describe('Timer 훅 테스트', () => {
-    jest.useFakeTimers();
-    const voteMock = jest.fn();
-    const timeLimit = 10;
-    const timeLimitMs = timeLimit * 1000;
-
-    it('타이머가 종료되었을 때 선택 완료를 누르지 않아도 선택된 옵션이 있으면 투표한다.', () => {
-      const isSelectedOption = true;
-      const isVoted = false;
-
-      const { result } = renderHook(() =>
-        useTimer({ timeLimit, isSelectedOption, isVoted, vote: voteMock }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(timeLimitMs);
-      });
-
-      expect(result.current.leftRoundTime).toBe(0);
-      expect(voteMock).toHaveBeenCalled();
-    });
-    it('타이머가 종료되었을 때 이미 투표를 했다면 또 투표를 하지 않는다.', () => {
-      const isSelectedOption = true;
-      const isVoted = true;
-
-      const { result } = renderHook(() =>
-        useTimer({ timeLimit, isSelectedOption, isVoted, vote: voteMock }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(timeLimitMs);
-      });
-
-      expect(result.current.leftRoundTime).toBe(0);
-      expect(voteMock).not.toHaveBeenCalled();
-    });
-    it('타이머가 종료되었을 때 선택된 옵션이 없다면 투표되지 않고 기권한다.', () => {
-      const isSelectedOption = false;
-      const isVoted = false;
-
-      const { result } = renderHook(() =>
-        useTimer({ timeLimit, isSelectedOption, isVoted, vote: voteMock }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(timeLimitMs);
-      });
-
-      expect(result.current.leftRoundTime).toBe(0);
-      expect(voteMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/pages/GamePage/components/SelectContainer/Timer/hooks/timerWorker.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/Timer/hooks/timerWorker.ts
@@ -1,0 +1,17 @@
+let intervalId: NodeJS.Timeout;
+
+self.onmessage = function (e) {
+  const { type, delay } = e.data;
+
+  if (type === 'start') {
+    const startTime = Date.now();
+
+    intervalId = setInterval(() => {
+      const elapsedTime = Date.now() - startTime;
+
+      self.postMessage({ elapsedTime });
+    }, delay);
+  } else if (type === 'stop') {
+    clearInterval(intervalId);
+  }
+};


### PR DESCRIPTION
## Issue Number
#403 

## As-Is
<!-- 문제 상황 정의 -->
- 다른 탭으로 이동하여 서비스를 백그라운드로 실행 시 타이머가 느려지는 현상 발생
  - 타이머가 느려질 경우, 타이머 숫자가 0이 되기 전에 게임이 끝나 사용자 경험에 악영향

## To-Be
<!-- 변경 사항 -->
- Web Worker를 사용하여 독립적인 worker thread에서 타이머 계산 로직 동작
- 탭이 전환되어 리소스 우선순위가 밀려 실행이 느려지는 문제를 worker를 통해 해결
- 기존의 타이머 오차 일부 개선 (2~30ms -> 5ms)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

### Web Worker를 활용하여 탭 전환 시 타이머 느려지는 현상 개선

기존에 setInterval만 사용했을 때는 메인 스레드에서만 동작하기 때문에 브라우저의 우선순위에 밀려 콜백 함수의 실행 또한 밀린 것을 확인할 수 있었습니다.

하지만 모바일 특성상 탭을 전환하는 경우가 많은데, 이때 타이머가 밀리면서 0초가 되지 않았는데 게임이 종료되는 현상이 발행하게 됩니다. 이는 사용자 경험에 좋지 않으므로 web worker를 사용하여 독립적인 스레드에서 타이머를 계산하도록 개선하였습니다. 이를 통해 탭을 전환하더라도 타이머가 일정하게 유지되는 것을 확인할 수 있습니다.

| ❌ worker 적용 전 탭 전환 시 타이머 | ✅ worker 적용 후 탭 전환 시 타이머 |
|:-:|:-:|
|<img alt="image" src="https://github.com/user-attachments/assets/53b9ca0d-7a27-4618-bbc9-7058873c3b68">|<img alt="image" src="https://github.com/user-attachments/assets/01e35a9c-7d1a-4a2c-89df-572883f80c28">|



| ❌ worker 적용 전 탭 전환 영상 | ✅ worker 적용 후 탭 전환 영상 |
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/58bf16a7-2318-431d-b84f-60763a5df680" />|<video src="https://github.com/user-attachments/assets/064002a1-b95f-4af8-a49a-9f02ab7190c6" />|



**메모리 누수 체크**

worker를 파일 상단에 선언했더니 첫 렌더링 외에는 제대로 동작하지 않았습니다. 

그래서 useEffect 내에 Worker 인스턴스를 생성했는데 메모리 누수가 걱정되어 체크해보니 기존 로직과 차이가 없는 걸 확인하였습니다.

| ❌ worker 적용 전 메모리 | ✅ worker 적용 후 메모리 |
|:-:|:-:|
|<img alt="image" src="https://github.com/user-attachments/assets/0360eda6-19ac-4aa0-bc63-a5ec6a86faa1">|<img alt="image" src="https://github.com/user-attachments/assets/01145ccb-6c73-4262-b699-d07598cf08cd">|

**브라우저 호환성  체크**

전 세계 약 98% 호환되며, Chrome, Safari, Mobile Chrome Anroid, Safari on IOS 모두 호환됨을 확인하였습니다.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7995a49b-3765-44a5-a2b5-4a90b615a5b6">


| ❌ 모바일 탭 전환 개선 전 | ✅ 모바일 탭 전환 개선 후 (추가 예정) |
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/c710f732-31e1-45b0-9155-eeaf3db5690c" />|-|

## (Optional) Additional Description

쿠키 정책 때문에 모바일 환경에서 탭 전환 시 실제로 오차가 줄어드는 건 확인하지 못했습니다ㅜ 

머지되고 확인하거나 나중에 쿠키 웹팩 설정을 해봐야할 것 같아요
