### PR TITLE
[REFACTOR] D-n 라벨 자동화 스크립트를 통한 코드 리뷰 병목 개선

### DIFF
--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -17,6 +17,23 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            // 현재 시간(Locale)
+            const curr = new Date();
+
+            // UTC 시간 계산
+            const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
+
+            // UTC to KST (UTC + 9시간)
+            const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+            const kr_curr = new Date(utc + KR_TIME_DIFF);
+            const KSTDayOfWeek = kr_curr.getDay(); // 0: 일요일, 6: 토요일
+
+            // 한국 시간 기준으로 주말인지 판단
+            if (KSTDayOfWeek === 0 || KSTDayOfWeek === 6) {
+              console.log("주말은 쉬어야죠!");
+              return;
+            }
+
             // 열려 있는 모든 PR을 가져온다.
             const pullRequests = await github.rest.pulls.list({
               owner,

--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -1,0 +1,83 @@
+name: Update PR Labels Daily
+
+on:
+  schedule:
+    - cron: "0 15 * * *" # 매일 밤 12시 실행
+  workflow_dispatch: # 수동 실행 허용
+
+jobs:
+  update-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update PR Labels with github-script
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // 열려 있는 모든 PR을 가져온다.
+            const pullRequests = await github.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+            });
+
+            console.log(pullRequests);
+
+            for (const pr of pullRequests.data) {
+              const { number, labels } = pr;
+
+              // Check if 'FE' label exists
+              // 열려 있는 PR에 FE 라벨이 달려있는지 확인한다.
+              const hasFeLabel = labels.some(label => label.name === 'FE');
+
+              if (!hasFeLabel) {
+                console.log(`PR #${number} does not have 'FE' label. Skipping.`);
+                continue;
+              }
+
+              // 'D-'로 시작하는 라벨이 있는지 확인한다.
+              const dLabel = labels.find(label => label.name.startsWith('D-'));
+
+              // 'D-'로 시작하는 라벨이 없다면 D-3' 라벨을 추가하고 끝낸다.
+              if (!dLabel) {
+                await github.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  labels: ['D-3'],
+                });
+                console.log(`Added 'D-3' label to PR #${number}`);
+                continue;
+              }
+
+              // 'D-n'로 시작하는 라벨이 있다면 n 값을 가져온다.
+              const currentDay = parseInt(dLabel.name.split('-')[1], 10);
+
+              if (isNaN(currentDay) || currentDay <= 1) {
+                console.log(`PR #${number} 유효하지 않은 라벨이거나 연산할 수 없는 라벨 '${dLabel.name}'.`);
+                continue;
+              }
+
+              // 현재 'D-n' 라벨을 제거한다.
+              await github.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: dLabel.name,
+              });
+
+              // 'D-(n-1)' 라벨을 새로 추가한다.
+              const newDay = currentDay - 1;
+              const newLabel = `D-${newDay}`;
+              await github.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: [newLabel],
+              });
+
+              console.log(`Updated PR #${number}: '${dLabel.name}' -> '${newLabel}'`);
+            }

--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -55,15 +55,15 @@ jobs:
               // 'D-'로 시작하는 라벨이 있는지 확인한다.
               const dLabel = labels.find(label => label.name.startsWith('D-'));
 
-              // 'D-'로 시작하는 라벨이 없다면 D-3' 라벨을 추가하고 끝낸다.
+              // 'D-'로 시작하는 라벨이 없다면 D-2' 라벨을 추가하고 끝낸다.
               if (!dLabel) {
                 await github.rest.issues.addLabels({
                   owner,
                   repo,
                   issue_number: number,
-                  labels: ['D-3'],
+                  labels: ['D-2'],
                 });
-                console.log(`Added 'D-3' label to PR #${number}`);
+                console.log(`Added 'D-2' label to PR #${number}`);
                 continue;
               }
 

--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -1,4 +1,4 @@
-name: Update PR Labels Daily
+name: FE PR D-n 라벨 수정 자동화
 
 on:
   schedule:
@@ -18,20 +18,17 @@ jobs:
             const repo = context.repo.repo;
 
             // 열려 있는 모든 PR을 가져온다.
-            const pullRequests = await github.pulls.list({
+            const pullRequests = await github.rest.pulls.list({
               owner,
               repo,
               state: 'open',
             });
 
-            console.log(pullRequests);
-
             for (const pr of pullRequests.data) {
               const { number, labels } = pr;
 
-              // Check if 'FE' label exists
               // 열려 있는 PR에 FE 라벨이 달려있는지 확인한다.
-              const hasFeLabel = labels.some(label => label.name === 'FE');
+              const hasFeLabel = labels.some(label => label.name === '🫧 FE');
 
               if (!hasFeLabel) {
                 console.log(`PR #${number} does not have 'FE' label. Skipping.`);
@@ -43,7 +40,7 @@ jobs:
 
               // 'D-'로 시작하는 라벨이 없다면 D-3' 라벨을 추가하고 끝낸다.
               if (!dLabel) {
-                await github.issues.addLabels({
+                await github.rest.issues.addLabels({
                   owner,
                   repo,
                   issue_number: number,
@@ -53,16 +50,22 @@ jobs:
                 continue;
               }
 
+              // 'D-0'이면 카운팅을 스킵한다.
+              if (dLabel.name === 'D-0') {
+                console.log(`PR #${number} already at 'D-0'. Skipping decrement.`);
+                continue;
+              }
+
               // 'D-n'로 시작하는 라벨이 있다면 n 값을 가져온다.
               const currentDay = parseInt(dLabel.name.split('-')[1], 10);
 
-              if (isNaN(currentDay) || currentDay <= 1) {
+              if (isNaN(currentDay) || currentDay < 1) {
                 console.log(`PR #${number} 유효하지 않은 라벨이거나 연산할 수 없는 라벨 '${dLabel.name}'.`);
                 continue;
               }
 
               // 현재 'D-n' 라벨을 제거한다.
-              await github.issues.removeLabel({
+              await github.rest.issues.removeLabel({
                 owner,
                 repo,
                 issue_number: number,
@@ -72,7 +75,7 @@ jobs:
               // 'D-(n-1)' 라벨을 새로 추가한다.
               const newDay = currentDay - 1;
               const newLabel = `D-${newDay}`;
-              await github.issues.addLabels({
+              await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: number,

--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -41,16 +41,18 @@ jobs:
               state: 'open',
             });
 
-            for (const pr of pullRequests.data) {
+            // "FE" 라벨이 포함된 PR만 필터링
+            const FEPullRequests = pullRequests.data.filter(pr => 
+              pr.labels.some(label => label.name.includes('FE'))
+            );
+
+            if (FEPullRequests.length === 0) {
+              console.log("열려있는 FE PR이 없습니다.");
+              return;
+            }
+
+            for (const pr of FEPullRequests) {
               const { number, labels } = pr;
-
-              // 열려 있는 PR에 FE 라벨이 달려있는지 확인한다.
-              const hasFeLabel = labels.some(label => label.name.includes('FE'));
-
-              if (!hasFeLabel) {
-                console.log(`PR #${number} does not have 'FE' label. Skipping.`);
-                continue;
-              }
 
               // 'D-'로 시작하는 라벨이 있는지 확인한다.
               const dLabel = labels.find(label => label.name.startsWith('D-'));

--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -45,7 +45,7 @@ jobs:
               const { number, labels } = pr;
 
               // 열려 있는 PR에 FE 라벨이 달려있는지 확인한다.
-              const hasFeLabel = labels.some(label => label.name === '🫧 FE');
+              const hasFeLabel = labels.some(label => label.name.includes('FE'));
 
               if (!hasFeLabel) {
                 console.log(`PR #${number} does not have 'FE' label. Skipping.`);


### PR DESCRIPTION
## Issue Number
#422 

## As-Is
<!-- 문제 상황 정의 -->
- 비대면으로 소통하다보니 코드 리뷰가 지연되어 병목 발생

## To-Be
<!-- 변경 사항 -->
- 오전 12시에 스크립트 동작(카운팅) + 주말 제외 3일
  - ex) "D-3" 라벨이였다면 스크립트 동작 후에는 "D-2" 라벨로 변경
  - 라벨 설정을 안했을 경우 PR 포함 3일이니 밤 12시에는 "D-2" 라벨 설정
- 이유: 알림보단 미리 카운팅 필요. 새벽에 작업하는 경우 많음. 주말은 쉬자.
- **D-0일 때 머지 조건 제거 X → branch 단위로 제거하는 것밖에 없음**
    - D-0 인 PR 1개만 있어도 branch rule이 제거되는 건 위험하다고 판단.
    - **D-0이 되면 PR 작성자가 without review 버튼을 통해 머지하기.**

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="600" src="https://github.com/user-attachments/assets/73f66949-6d6d-469a-82ed-978e9b22b442">

## (Optional) Additional Description

노션 논의 사항 정리

<img width="600" src="https://github.com/user-attachments/assets/6d1bb430-a272-4050-87fb-62c7171322d6">
