### PR TITLE
[FEAT] PR 리뷰 리마인더 및 Discord 알림 워크플로우 생성

### DIFF
--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -45,7 +45,13 @@ jobs:
               .map(pr => {
                 const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
                 const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
-                return { ...pr, urgency, dLabelName: dLabel?.name || 'D-unknown' };
+                return { 
+                  ...pr, 
+                  urgency, 
+                  dLabelName: dLabel?.name || 'D-unknown',
+                  updatedAt: pr.updated_at, // 마지막 수정 시간 추가
+                  createdAt: pr.created_at, // 생성 시간 추가
+                };
               })
               .sort((a, b) => a.urgency - b.urgency);
 
@@ -85,14 +91,18 @@ jobs:
 
                 const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
+                // 생성일과 마지막 수정일 표시
+                const createdDate = new Date(pr.createdAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+                const lastUpdated = new Date(pr.updatedAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+
                 // 모든 리뷰어가 APPROVED인 경우 메시지 생성
                 if (allApproved) {
                   const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
-                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
+                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
                 }
 
                 // 일반적인 리마인드 메시지 생성
-                return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n링크: ${pr.html_url}`;
+                return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n링크: ${pr.html_url}`;
               })
             );
 

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -1,0 +1,126 @@
+name: FE Review Reminder for Discord
+
+on:
+  schedule:
+    - cron: '0 2 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 11시에 실행
+jobs:
+  review-reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Send Reminder to Discord
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK: ${{ secrets.FE_REVIEW_NOTIFICATION_WEBHOOK_URL }}
+        run: |
+          const discordMentions = {
+            'useon': '썬데이',
+            'novice0840': '포메',
+            'rbgksqkr': '마루',
+          };
+
+          const owner = '${{ github.repository_owner }}';
+          const repo = '${{ github.event.repository.name }}';
+          const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+          const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
+
+          async function main() {
+            # 열린 PR 목록 가져오기
+            const pullRequests = await fetch(
+              `https://api.github.com/repos/${owner}/${repo}/pulls`,
+              {
+                headers: {
+                  Authorization: `token ${GITHUB_TOKEN}`,
+                  Accept: 'application/vnd.github.v3+json'
+                }
+              }
+            ).then(res => res.json());
+            # 🫧 FE 라벨이 달린 PR만 필터링하고, D-값으로 우선 순위 정렬
+            const fePrs = pullRequests
+              .filter(pr => pr.labels.some(label => label.name === '🫧 FE'))
+              .map(pr => {
+                const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
+                const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
+                return { ...pr, urgency };
+              })
+              .sort((a, b) => a.urgency - b.urgency);
+            
+            # 열린 PR 중 FE PR이 없는 경우 실행 종료
+            if (fePrs.length === 0) {
+              console.log('No FE PRs to remind.');
+              return;
+            }
+
+            const messages = await Promise.all(
+              fePrs.map(async pr => {
+                # 리뷰 상태 가져오기
+                const reviews = await getReviews(owner, repo, pr.number);
+                const requestedReviewers = pr.requested_reviewers.map(r => r.login);
+
+                # 승인한 리뷰어 목록 확인
+                const approvedReviewers = reviews.filter(review => review.state === 'APPROVED').map(r => r.user.login);
+                const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
+
+                # 각 리뷰어의 상태 생성
+                const reviewStatuses = reviews.map(review => {
+                  const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
+                  const reviewState = review.state.toLowerCase();
+                  return review.state === 'APPROVED' 
+                    ? `**${discordUsername}(${reviewState})**` # APPROVED인 경우 멘션 없이 이름만 표시
+                    : `${discordUsername}(${reviewState})`; # 나머지 상태인 경우 멘션
+                });
+
+                # 아직 리뷰를 시작하지 않은 리뷰어 표시
+                const notStartedReviewers = requestedReviewers.filter(
+                  reviewer => !reviews.some(review => review.user.login === reviewer)
+                );
+
+                const notStartedMentions = notStartedReviewers.map(reviewer => {
+                  const discordUsername = discordMentions[reviewer] || `@${reviewer}`;
+                  return `${discordUsername}(not started)`;
+                });
+
+                const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
+
+                # 모든 리뷰어가 APPROVED인 경우 메시지 생성
+                if (allApproved) {
+                  const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
+                  return `제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
+                }
+
+                # 일반적인 리마인드 메시지 생성
+                return `제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n링크: ${pr.html_url}`;
+              })
+            );
+
+            # 최종 메시지 Discord에 전송
+            const finalMessage = `🍀 [FE] 오늘의 PR 리뷰 목록 🍀\n\n${messages.join('\n\n')}`;
+
+            await fetch(DISCORD_WEBHOOK, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ content: finalMessage }),
+            });
+          }
+
+          # 특정 PR의 리뷰 상태 가져오기
+          async function getReviews(owner, repo, prNumber) {
+            return await fetch(
+              `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
+              {
+                headers: {
+                  Authorization: `token ${GITHUB_TOKEN}`,
+                  Accept: 'application/vnd.github.v3+json'
+                }
+              }
+            ).then(res => res.json());
+          }
+
+          # 메인 함수 실행 및 에러 처리
+          main().catch(err => {
+            console.error('Error:', err);
+            process.exit(1);
+          });

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -23,7 +23,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // GitHub 사용자명과 디스코드 아이디 또는 닉네임으로 매핑
+            // GitHub 사용자명과 Discord 멘션 정보 매핑
             const discordMentions = JSON.parse(process.env.DISCORD_MENTION);
 
             const discordNotMentions = {
@@ -77,44 +77,42 @@ jobs:
                   const reviews = await getReviews(owner, repo, pr.number);
                   const requestedReviewers = pr.requested_reviewers.map(r => r.login);
 
-                  // 승인된 리뷰어 목록 확인
-                  const approvedReviewers = reviews.filter(review => review.state === 'APPROVED').map(r => r.user.login);
-                  const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
-
-                  // 각 리뷰어의 상태 생성
-                  const reviewStatuses = reviews.map(review => {                    
-                    // state마다 약자 정의
-                    const stateAbbreviations = {
-                      APPROVED: 'A',      
-                      CHANGES_REQUESTED: 'RC', 
-                      COMMENTED: 'C',
-                    };
-
-                    // 약자가 없는 상태일 경우 기본적으로 state 그대로 사용
-                    const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
-
-                    return review.state === 'APPROVED'
-                      ? `${discordNotMentions[review.user.login]}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `<@${discordMentions[review.user.login]}>(${reviewState})`; // 나머지 상태인 경우 멘션
+                  // 리뷰 상태를 관리하는 Map 객체 생성
+                  const reviewStates = new Map();
+                  reviews.forEach(review => {
+                    const reviewer = review.user.login;
+                    const state = review.state;
+                    if (reviewer !== pr.user.login) { // PR 작성자는 제외
+                      reviewStates.set(reviewer, state);
+                    }
                   });
 
-                  // 리뷰를 시작하지 않은 리뷰어 멘션
-                  const notStartedReviewers = requestedReviewers.filter(
-                    reviewer => !reviews.some(review => review.user.login === reviewer)
-                  );
+                  // 리뷰 상태 메시지 생성
+                  const reviewStatuses = Array.from(reviewStates.entries()).map(([reviewer, state]) => {
+                    const discordUsername = discordMentions[reviewer] || `${reviewer}`;
+                    const stateAbbreviations = {
+                      APPROVED: 'A',
+                      CHANGES_REQUESTED: 'RC',
+                      COMMENTED: 'C',
+                    };
+                    const reviewState = stateAbbreviations[state] || state.toLowerCase();
+                    return state === 'APPROVED'
+                      ? `${discordNotMentions[reviewer]}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `<@${discordMentions[reviewer]}>(${reviewState})`; // 나머지 상태인 경우 멘션
+                  });
 
+                  // 리뷰를 시작하지 않은 리뷰어 추가
+                  const notStartedReviewers = requestedReviewers.filter(
+                    reviewer => !reviewStates.has(reviewer) && reviewer !== pr.user.login // PR 작성자 제외
+                  );
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
                     return `<@${discordMentions[reviewer]}>(X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
-                  // 생성일과 마지막 수정일 표시
-                  const createdDate = new Date(pr.createdAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
-                  const lastUpdated = new Date(pr.updatedAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
-
                   // 모든 리뷰어가 APPROVED인 경우
-                  if (allApproved) {
+                  if (Array.from(reviewStates.values()).every(state => state === 'APPROVED')) {
                     const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
                     return `[[${pr.dLabelName}] ${pr.title}](<${pr.html_url}>)\n리뷰어: ${reviewStatusMessage.join(', ')}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
                   }
@@ -131,7 +129,7 @@ jobs:
                 body: JSON.stringify({
                   content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
                   allowed_mentions: {
-                    parse: ["users"],
+                    parse: ["users"], // 멘션 가능한 사용자만 허용
                   },
                 }),
               });

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -94,8 +94,8 @@ jobs:
                     const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
 
                     return review.state === 'APPROVED'
-                      ? `${discordNotMentions[review.user.login]}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `<@${discordMentions[review.user.login]}>(${reviewState})`; // 나머지 상태인 경우 멘션
+                      ? `${discordNotMentions[review.user.login]} ${reviewState}` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `<@${discordMentions[review.user.login]}> ${reviewState}`; // 나머지 상태인 경우 멘션
                   });
 
                   // 리뷰를 시작하지 않은 리뷰어 멘션
@@ -104,7 +104,7 @@ jobs:
                   );
 
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
-                    return `<@${discordMentions[reviewer]}>(X)`;
+                    return `<@${discordMentions[reviewer]}> (X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
@@ -115,7 +115,7 @@ jobs:
 
                   // 모든 리뷰어가 APPROVED인 경우
                   if (allApproved) {
-                    const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
+                    const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
                     return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
                   }
 

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -7,45 +7,31 @@ on:
   schedule:
     - cron: '0 2 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 11시에 실행
   workflow_dispatch:
+
 jobs:
   review-reminder:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
       - name: Send Reminder to Discord
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK: ${{ secrets.FE_REVIEW_NOTIFICATION_WEBHOOK_URL }}
-        run: |
-          const discordMentions = {
-            'useon': '썬데이',
-            'novice0840': '포메',
-            'rbgksqkr': '마루',
-          };
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-          const owner = '${{ github.repository_owner }}';
-          const repo = '${{ github.event.repository.name }}';
-          const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-          const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
-
-          async function main() {
-            // 열린 PR 목록 가져오기
-            const pullRequests = await fetch(
-              `https://api.github.com/repos/${owner}/${repo}/pulls`,
-              {
-                headers: {
-                  Authorization: `token ${GITHUB_TOKEN}`,
-                  Accept: 'application/vnd.github.v3+json',
-                },
-              }
-            ).then(res => res.json());
+            // 열려 있는 PR 목록 가져오기
+            const pullRequests = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+            });
 
             // FE 라벨이 달린 PR을 D-DAY가 임박한 순서로 정렬
-            const fePrs = pullRequests
-            .filter(pr => pr.labels.some(label => label.name.includes('FE')))
+            const fePrs = pullRequests.data
+              .filter(pr => pr.labels.some(label => label.name.includes('FE')))
               .map(pr => {
                 const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
                 const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
@@ -53,8 +39,8 @@ jobs:
                   ...pr, 
                   urgency, 
                   dLabelName: dLabel?.name || 'D-unknown',
-                  updatedAt: pr.updated_at, // 마지막 수정 시간 추가
-                  createdAt: pr.created_at, // 생성 시간 추가
+                  updatedAt: pr.updated_at,
+                  createdAt: pr.created_at,
                 };
               })
               .sort((a, b) => a.urgency - b.urgency);
@@ -111,30 +97,9 @@ jobs:
             );
 
             // 최종 메시지 Discord에 전송
-            const finalMessage = `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`;
-
-            await fetch(DISCORD_WEBHOOK, {
+            const fetch = require('node-fetch');
+            await fetch(process.env.DISCORD_WEBHOOK, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ content: finalMessage }),
+              body: JSON.stringify({ content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}` }),
             });
-          }
-
-          // 특정 PR의 리뷰 상태 가져오기
-          async function getReviews(owner, repo, prNumber) {
-            return await fetch(
-              `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
-              {
-                headers: {
-                  Authorization: `token ${GITHUB_TOKEN}`,
-                  Accept: 'application/vnd.github.v3+json',
-                },
-              }
-            ).then(res => res.json());
-          }
-
-          // 메인 함수 실행 및 에러 처리
-          main().catch(err => {
-            console.error('Error:', err);
-            process.exit(1);
-          });

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           DISCORD_WEBHOOK: ${{ secrets.FE_REVIEW_NOTIFICATION_WEBHOOK_URL }}
-          DISCORD_MENTION: ${{  secrets.FE_GITHUB_DISCORD_ID }}
+          DISCORD_MENTION: ${{ secrets.FE_GITHUB_DISCORD_ID }}
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -115,15 +115,14 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-              try {
-                await fetch(process.env.DISCORD_WEBHOOK, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
-                  }),
-                });
-              } catch (error) {
-                console.error('Error sending reminder to Discord:', error.message);
-                throw error; // 워크플로우 실패 상태 반환
-              }
+              await fetch(process.env.DISCORD_WEBHOOK, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
+                }),
+              });
+            } catch (error) {
+              console.error('Error processing FE PR reminders:', error.message);
+              throw error; // 워크플로우 실패 상태 반환
+            }

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -24,9 +24,9 @@ jobs:
 
             // GitHub 사용자명을 Discord 멘션으로 매핑
             const discordMentions = {
-              'useon': '썬데이',
-              'novice0840': '포메',
-              'rbgksqkr': '마루',
+              'useon': '@썬데이',
+              'novice0840': '@포메',
+              'rbgksqkr': '@마루',
             };
 
             async function getReviews(owner, repo, prNumber) {

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -131,7 +131,7 @@ jobs:
                 body: JSON.stringify({
                   content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
                   allowed_mentions: {
-                    parse: ["user"],
+                    parse: ["users"],
                   },
                 }),
               });

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -124,8 +124,6 @@ jobs:
                 })
               );
 
-              const allowedUsers = Object.values(discordMentions);
-
               // 최종 메시지 Discord에 전송
               await fetch(process.env.DISCORD_WEBHOOK, {
                 method: 'POST',
@@ -133,7 +131,7 @@ jobs:
                 body: JSON.stringify({
                   content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
                   allowed_mentions: {
-                    users: allowedUsers, // 멘션 가능 사용자 명시
+                    parse: ["user"],
                   },
                 }),
               });

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -94,8 +94,8 @@ jobs:
                     const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
 
                     return review.state === 'APPROVED'
-                      ? `${discordNotMentions[review.user.login]} ${reviewState}` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `<@${discordMentions[review.user.login]}> ${reviewState}`; // 나머지 상태인 경우 멘션
+                      ? `${discordNotMentions[review.user.login]}${reviewState}` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `<@${discordMentions[review.user.login]}>${reviewState}`; // 나머지 상태인 경우 멘션
                   });
 
                   // 리뷰를 시작하지 않은 리뷰어 멘션
@@ -104,7 +104,7 @@ jobs:
                   );
 
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
-                    return `<@${discordMentions[reviewer]}> (X)`;
+                    return `<@${discordMentions[reviewer]}>(X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
@@ -124,12 +124,17 @@ jobs:
                 })
               );
 
+              const allowedUsers = Object.values(discordMentions);
+
               // 최종 메시지 Discord에 전송
               await fetch(process.env.DISCORD_WEBHOOK, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                   content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
+                  allowed_mentions: {
+                    users: allowedUsers, // 멘션 가능 사용자 명시
+                  },
                 }),
               });
             } catch (error) {

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -17,16 +17,19 @@ jobs:
         uses: actions/github-script@v7
         env:
           DISCORD_WEBHOOK: ${{ secrets.FE_REVIEW_NOTIFICATION_WEBHOOK_URL }}
+          DISCORD_MENTION: ${{  secrets.FE_GITHUB_DISCORD_ID }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // GitHub 사용자명을 Discord 멘션으로 매핑
-            const discordMentions = {
-              'useon': '@썬데이',
-              'novice0840': '@포메',
-              'rbgksqkr': '@마루',
+            // GitHub 사용자명과 디스코드 아이디 또는 닉네임으로 매핑
+            const discordMentions = JSON.parse(process.env.DISCORD_MENTION);
+
+            const discordNotMentions = {
+              'useon': '썬데이',
+              'novice0840': '포메',
+              'rbgksqkr': '마루',
             };
 
             async function getReviews(owner, repo, prNumber) {
@@ -79,9 +82,7 @@ jobs:
                   const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
 
                   // 각 리뷰어의 상태 생성
-                  const reviewStatuses = reviews.map(review => {
-                    const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
-                    
+                  const reviewStatuses = reviews.map(review => {                    
                     // state마다 약자 정의
                     const stateAbbreviations = {
                       APPROVED: 'A',      
@@ -93,18 +94,17 @@ jobs:
                     const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
 
                     return review.state === 'APPROVED'
-                      ? `${discordUsername.replace('@', '')} (${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `${discordUsername} (${reviewState})`; // 나머지 상태인 경우 멘션
+                      ? `${discordNotMentions[review.user.login]}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `<@${discordMentions[review.user.login]}>(${reviewState})`; // 나머지 상태인 경우 멘션
                   });
 
-                  // 리뷰를 시작하지 않은 리뷰어
+                  // 리뷰를 시작하지 않은 리뷰어 멘션
                   const notStartedReviewers = requestedReviewers.filter(
                     reviewer => !reviews.some(review => review.user.login === reviewer)
                   );
 
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
-                    const discordUsername = discordMentions[reviewer] || `@${reviewer}`;
-                    return `${discordUsername} (X)`;
+                    return `<@${discordMentions[reviewer]}>(X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -3,6 +3,7 @@ name: FE Review Reminder for Discord
 on:
   schedule:
     - cron: '0 2 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 11시에 실행
+  workflow_dispatch:
 jobs:
   review-reminder:
     runs-on: ubuntu-latest

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -116,11 +116,11 @@ jobs:
                   // 모든 리뷰어가 APPROVED인 경우
                   if (allApproved) {
                     const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
-                    return `[[${pr.dLabelName}] ${pr.title}](${pr.html_url})\n리뷰어: ${reviewStatusMessage.join(', ')}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
+                    return `[[${pr.dLabelName}] ${pr.title}](<${pr.html_url}>)\n리뷰어: ${reviewStatusMessage.join(', ')}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
                   }
 
                   // 일반적인 리마인드 메시지
-                  return `[[${pr.dLabelName}] ${pr.title}](${pr.html_url})\n리뷰어: ${reviewStatusMessage.join(', ')}`;
+                  return `[[${pr.dLabelName}] ${pr.title}](<${pr.html_url}>)\n리뷰어: ${reviewStatusMessage.join(', ')}`;
                 })
               );
 

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -94,8 +94,8 @@ jobs:
                     const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
 
                     return review.state === 'APPROVED'
-                      ? `${discordNotMentions[review.user.login]}${reviewState}` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `<@${discordMentions[review.user.login]}>${reviewState}`; // 나머지 상태인 경우 멘션
+                      ? `${discordNotMentions[review.user.login]}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `<@${discordMentions[review.user.login]}>(${reviewState})`; // 나머지 상태인 경우 멘션
                   });
 
                   // 리뷰를 시작하지 않은 리뷰어 멘션
@@ -116,11 +116,11 @@ jobs:
                   // 모든 리뷰어가 APPROVED인 경우
                   if (allApproved) {
                     const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
-                    return `[${pr.dLabelName} ${pr.title}](${pr.html_url})\n현황: ${reviewStatusMessage.join(', ')}\n마지막 수정: ${lastUpdated}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
+                    return `[[${pr.dLabelName}] ${pr.title}](${pr.html_url})\n리뷰어: ${reviewStatusMessage.join(', ')}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
                   }
 
                   // 일반적인 리마인드 메시지
-                  return `[${pr.dLabelName} ${pr.title}](${pr.html_url})\n현황: ${reviewStatusMessage.join(', ')}\n마지막 수정: ${lastUpdated}`;
+                  return `[[${pr.dLabelName}] ${pr.title}](${pr.html_url})\n리뷰어: ${reviewStatusMessage.join(', ')}`;
                 })
               );
 

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -115,13 +115,15 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-              const fetch = require('node-fetch');
-              await fetch(process.env.DISCORD_WEBHOOK, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}` }),
-              });
-            } catch (error) {
-              console.error('Error sending reminder to Discord:', error.message);
-              throw error; // 워크플로우 실패 상태 반환
-            }
+              try {
+                await fetch(process.env.DISCORD_WEBHOOK, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
+                  }),
+                });
+              } catch (error) {
+                console.error('Error sending reminder to Discord:', error.message);
+                throw error; // 워크플로우 실패 상태 반환
+              }

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -116,11 +116,11 @@ jobs:
                   // 모든 리뷰어가 APPROVED인 경우
                   if (allApproved) {
                     const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
-                    return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
+                    return `[${pr.dLabelName} ${pr.title}](${pr.html_url})\n현황: ${reviewStatusMessage.join(', ')}\n마지막 수정: ${lastUpdated}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
                   }
 
                   // 일반적인 리마인드 메시지
-                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n링크: ${pr.html_url}`;
+                  return `[${pr.dLabelName} ${pr.title}](${pr.html_url})\n현황: ${reviewStatusMessage.join(', ')}\n마지막 수정: ${lastUpdated}`;
                 })
               );
 

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -42,7 +42,7 @@ jobs:
 
             // FE 라벨이 달린 PR을 D-DAY가 임박한 순서로 정렬
             const fePrs = pullRequests
-              .filter(pr => pr.labels.some(label => label.name === '🫧 FE'))
+            .filter(pr => pr.labels.some(label => label.name.includes('FE')))
               .map(pr => {
                 const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
                 const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -111,8 +111,13 @@ jobs:
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
-                  // 모든 리뷰어가 APPROVED인 경우
-                  if (Array.from(reviewStates.values()).every(state => state === 'APPROVED')) {
+                  const allReviewersApproved = requestedReviewers.every(
+                    reviewer => reviewStates.get(reviewer) === 'APPROVED'
+                  );
+                  const noPendingReviews = notStartedReviewers.length === 0;
+
+                  // 모든 리뷰어가 APPROVED 상태이고 리뷰를 시작하지 않은 리뷰어가 없는 경우
+                  if (allReviewersApproved && noPendingReviews) {
                     const authorMention = discordMentions[pr.user.login] || `${pr.user.login}`;
                     return `[[${pr.dLabelName}] ${pr.title}](<${pr.html_url}>)\n리뷰어: ${reviewStatusMessage.join(', ')}\n<@${authorMention}>, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀`;
                   }

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -81,10 +81,20 @@ jobs:
                   // 각 리뷰어의 상태 생성
                   const reviewStatuses = reviews.map(review => {
                     const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
-                    const reviewState = review.state.toLowerCase();
+                    
+                    // state마다 약자 정의
+                    const stateAbbreviations = {
+                      APPROVED: 'A',      
+                      CHANGES_REQUESTED: 'RC', 
+                      COMMENTED: 'C',
+                    };
+
+                    // 약자가 없는 상태일 경우 기본적으로 state 그대로 사용
+                    const reviewState = stateAbbreviations[review.state] || review.state.toLowerCase();
+
                     return review.state === 'APPROVED'
-                      ? `${discordUsername.replace('@', '')}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
-                      : `${discordUsername}(${reviewState})`; // 나머지 상태인 경우 멘션
+                      ? `${discordUsername.replace('@', '')} (${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `${discordUsername} (${reviewState})`; // 나머지 상태인 경우 멘션
                   });
 
                   // 리뷰를 시작하지 않은 리뷰어
@@ -94,7 +104,7 @@ jobs:
 
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
                     const discordUsername = discordMentions[reviewer] || `@${reviewer}`;
-                    return `${discordUsername}(not started)`;
+                    return `${discordUsername} (X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -125,7 +125,7 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-              await fetch(process.env.DISCORD_WEBHOOK, {
+              const response = await fetch(process.env.DISCORD_WEBHOOK, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -135,6 +135,8 @@ jobs:
                   },
                 }),
               });
+
+              console.log('Response status:', response.status);
             } catch (error) {
               console.error('Error processing FE PR reminders:', error.message);
               throw error; // 워크플로우 실패 상태 반환

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -28,27 +28,28 @@ jobs:
           const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
 
           async function main() {
-            # 열린 PR 목록 가져오기
+            // 열린 PR 목록 가져오기
             const pullRequests = await fetch(
               `https://api.github.com/repos/${owner}/${repo}/pulls`,
               {
                 headers: {
                   Authorization: `token ${GITHUB_TOKEN}`,
-                  Accept: 'application/vnd.github.v3+json'
-                }
+                  Accept: 'application/vnd.github.v3+json',
+                },
               }
             ).then(res => res.json());
-            # 🫧 FE 라벨이 달린 PR만 필터링하고, D-값으로 우선 순위 정렬
+
+            // FE 라벨이 달린 PR을 D-DAY가 임박한 순서로 정렬
             const fePrs = pullRequests
               .filter(pr => pr.labels.some(label => label.name === '🫧 FE'))
               .map(pr => {
                 const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
                 const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
-                return { ...pr, urgency };
+                return { ...pr, urgency, dLabelName: dLabel?.name || 'D-unknown' };
               })
               .sort((a, b) => a.urgency - b.urgency);
-            
-            # 열린 PR 중 FE PR이 없는 경우 실행 종료
+
+            // 열린 PR 중 FE PR이 없는 경우 실행 종료
             if (fePrs.length === 0) {
               console.log('No FE PRs to remind.');
               return;
@@ -56,24 +57,23 @@ jobs:
 
             const messages = await Promise.all(
               fePrs.map(async pr => {
-                # 리뷰 상태 가져오기
                 const reviews = await getReviews(owner, repo, pr.number);
                 const requestedReviewers = pr.requested_reviewers.map(r => r.login);
 
-                # 승인한 리뷰어 목록 확인
+                // 승인한 리뷰어 목록 확인
                 const approvedReviewers = reviews.filter(review => review.state === 'APPROVED').map(r => r.user.login);
                 const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
 
-                # 각 리뷰어의 상태 생성
+                // 각 리뷰어의 상태 생성
                 const reviewStatuses = reviews.map(review => {
                   const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
                   const reviewState = review.state.toLowerCase();
-                  return review.state === 'APPROVED' 
-                    ? `**${discordUsername}(${reviewState})**` # APPROVED인 경우 멘션 없이 이름만 표시
-                    : `${discordUsername}(${reviewState})`; # 나머지 상태인 경우 멘션
+                  return review.state === 'APPROVED'
+                    ? `${discordUsername.replace('@', '')}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                    : `${discordUsername}(${reviewState})`; // 나머지 상태인 경우 멘션
                 });
 
-                # 아직 리뷰를 시작하지 않은 리뷰어 표시
+                // 아직 리뷰를 시작하지 않은 리뷰어 표시
                 const notStartedReviewers = requestedReviewers.filter(
                   reviewer => !reviews.some(review => review.user.login === reviewer)
                 );
@@ -85,19 +85,19 @@ jobs:
 
                 const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
-                # 모든 리뷰어가 APPROVED인 경우 메시지 생성
+                // 모든 리뷰어가 APPROVED인 경우 메시지 생성
                 if (allApproved) {
                   const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
-                  return `제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
+                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
                 }
 
-                # 일반적인 리마인드 메시지 생성
-                return `제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n링크: ${pr.html_url}`;
+                // 일반적인 리마인드 메시지 생성
+                return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n링크: ${pr.html_url}`;
               })
             );
 
-            # 최종 메시지 Discord에 전송
-            const finalMessage = `🍀 [FE] 오늘의 PR 리뷰 목록 🍀\n\n${messages.join('\n\n')}`;
+            // 최종 메시지 Discord에 전송
+            const finalMessage = `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`;
 
             await fetch(DISCORD_WEBHOOK, {
               method: 'POST',
@@ -106,20 +106,20 @@ jobs:
             });
           }
 
-          # 특정 PR의 리뷰 상태 가져오기
+          // 특정 PR의 리뷰 상태 가져오기
           async function getReviews(owner, repo, prNumber) {
             return await fetch(
               `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
               {
                 headers: {
                   Authorization: `token ${GITHUB_TOKEN}`,
-                  Accept: 'application/vnd.github.v3+json'
-                }
+                  Accept: 'application/vnd.github.v3+json',
+                },
               }
             ).then(res => res.json());
           }
 
-          # 메인 함수 실행 및 에러 처리
+          // 메인 함수 실행 및 에러 처리
           main().catch(err => {
             console.error('Error:', err);
             process.exit(1);

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -1,6 +1,9 @@
 name: FE Review Reminder for Discord
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
     - cron: '0 2 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 11시에 실행
   workflow_dispatch:

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -22,84 +22,106 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // 열려 있는 PR 목록 가져오기
-            const pullRequests = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-            });
+            // GitHub 사용자명을 Discord 멘션으로 매핑
+            const discordMentions = {
+              'useon': '썬데이',
+              'novice0840': '포메',
+              'rbgksqkr': '마루',
+            };
 
-            // FE 라벨이 달린 PR을 D-DAY가 임박한 순서로 정렬
-            const fePrs = pullRequests.data
-              .filter(pr => pr.labels.some(label => label.name.includes('FE')))
-              .map(pr => {
-                const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
-                const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
-                return { 
-                  ...pr, 
-                  urgency, 
-                  dLabelName: dLabel?.name || 'D-unknown',
-                  updatedAt: pr.updated_at,
-                  createdAt: pr.created_at,
-                };
-              })
-              .sort((a, b) => a.urgency - b.urgency);
-
-            // 열린 PR 중 FE PR이 없는 경우 실행 종료
-            if (fePrs.length === 0) {
-              console.log('No FE PRs to remind.');
-              return;
+            async function getReviews(owner, repo, prNumber) {
+              // 특정 PR의 리뷰 상태 가져오기
+              const reviews = await github.rest.pulls.listReviews({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              return reviews.data;
             }
 
-            const messages = await Promise.all(
-              fePrs.map(async pr => {
-                const reviews = await getReviews(owner, repo, pr.number);
-                const requestedReviewers = pr.requested_reviewers.map(r => r.login);
+            try {
+              // 열려 있는 PR 목록 가져오기
+              const pullRequests = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+              });
 
-                // 승인한 리뷰어 목록 확인
-                const approvedReviewers = reviews.filter(review => review.state === 'APPROVED').map(r => r.user.login);
-                const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
+              // FE 라벨이 달린 PR을 D-DAY가 임박한 순서로 정렬
+              const fePrs = pullRequests.data
+                .filter(pr => pr.labels.some(label => label.name.includes('FE')))
+                .map(pr => {
+                  const dLabel = pr.labels.find(label => label.name.startsWith('D-'));
+                  const urgency = dLabel ? parseInt(dLabel.name.split('-')[1], 10) : Number.MAX_SAFE_INTEGER;
+                  return {
+                    ...pr,
+                    urgency,
+                    dLabelName: dLabel?.name || 'D-unknown',
+                    updatedAt: pr.updated_at,
+                    createdAt: pr.created_at,
+                  };
+                })
+                .sort((a, b) => a.urgency - b.urgency);
 
-                // 각 리뷰어의 상태 생성
-                const reviewStatuses = reviews.map(review => {
-                  const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
-                  const reviewState = review.state.toLowerCase();
-                  return review.state === 'APPROVED'
-                    ? `${discordUsername.replace('@', '')}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
-                    : `${discordUsername}(${reviewState})`; // 나머지 상태인 경우 멘션
-                });
+              // 열린 PR 중 FE PR이 없는 경우 실행 종료
+              if (fePrs.length === 0) {
+                console.log('No FE PRs to remind.');
+                return;
+              }
 
-                // 아직 리뷰를 시작하지 않은 리뷰어 표시
-                const notStartedReviewers = requestedReviewers.filter(
-                  reviewer => !reviews.some(review => review.user.login === reviewer)
-                );
+              const messages = await Promise.all(
+                fePrs.map(async pr => {
+                  const reviews = await getReviews(owner, repo, pr.number);
+                  const requestedReviewers = pr.requested_reviewers.map(r => r.login);
 
-                const notStartedMentions = notStartedReviewers.map(reviewer => {
-                  const discordUsername = discordMentions[reviewer] || `@${reviewer}`;
-                  return `${discordUsername}(not started)`;
-                });
+                  // 승인된 리뷰어 목록 확인
+                  const approvedReviewers = reviews.filter(review => review.state === 'APPROVED').map(r => r.user.login);
+                  const allApproved = requestedReviewers.every(reviewer => approvedReviewers.includes(reviewer));
 
-                const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
+                  // 각 리뷰어의 상태 생성
+                  const reviewStatuses = reviews.map(review => {
+                    const discordUsername = discordMentions[review.user.login] || `@${review.user.login}`;
+                    const reviewState = review.state.toLowerCase();
+                    return review.state === 'APPROVED'
+                      ? `${discordUsername.replace('@', '')}(${reviewState})` // APPROVED인 경우 멘션 없이 이름만 표시
+                      : `${discordUsername}(${reviewState})`; // 나머지 상태인 경우 멘션
+                  });
 
-                // 생성일과 마지막 수정일 표시
-                const createdDate = new Date(pr.createdAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
-                const lastUpdated = new Date(pr.updatedAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+                  // 리뷰를 시작하지 않은 리뷰어
+                  const notStartedReviewers = requestedReviewers.filter(
+                    reviewer => !reviews.some(review => review.user.login === reviewer)
+                  );
 
-                // 모든 리뷰어가 APPROVED인 경우 메시지 생성
-                if (allApproved) {
-                  const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
-                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
-                }
+                  const notStartedMentions = notStartedReviewers.map(reviewer => {
+                    const discordUsername = discordMentions[reviewer] || `@${reviewer}`;
+                    return `${discordUsername}(not started)`;
+                  });
 
-                // 일반적인 리마인드 메시지 생성
-                return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n링크: ${pr.html_url}`;
-              })
-            );
+                  const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
-            // 최종 메시지 Discord에 전송
-            const fetch = require('node-fetch');
-            await fetch(process.env.DISCORD_WEBHOOK, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}` }),
-            });
+                  // 생성일과 마지막 수정일 표시
+                  const createdDate = new Date(pr.createdAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+                  const lastUpdated = new Date(pr.updatedAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+
+                  // 모든 리뷰어가 APPROVED인 경우
+                  if (allApproved) {
+                    const authorMention = discordMentions[pr.user.login] || `@${pr.user.login}`;
+                    return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n${authorMention}, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀\n링크: ${pr.html_url}`;
+                  }
+
+                  // 일반적인 리마인드 메시지
+                  return `마감일: [${pr.dLabelName}]\n제목: ${pr.title}\n현황: ${reviewStatusMessage.join(', ')}\n생성일: ${createdDate}\n마지막 수정: ${lastUpdated}\n링크: ${pr.html_url}`;
+                })
+              );
+
+              // 최종 메시지 Discord에 전송
+              const fetch = require('node-fetch');
+              await fetch(process.env.DISCORD_WEBHOOK, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}` }),
+              });
+            } catch (error) {
+              console.error('Error sending reminder to Discord:', error.message);
+              throw error; // 워크플로우 실패 상태 반환
+            }


### PR DESCRIPTION
## Issue Number
#424 

## As-Is
<!-- 문제 상황 정의 -->
비대면 작업 또는 여러 일정을 병행하는 경우 코드 리뷰를 하지 않은 PR을 잊는 경우가 생겨 코드 리뷰 병목 현상이 발생했습니다.

## To-Be
<!-- 변경 사항 -->
코드 리뷰를 리마인드하는 스크립트를 작성하여 디스코드 알림과 연동하도록 합니다.

알림 형식은 다음과 같습니다.

- 열려 있는 PR 중 FE라벨이 달린 PR이 없으면 알림을 발송하지 않는다.
- 열려 있는 PR 중 FE라벨이 달린 PR이 있으면 평일 오전 11시에 스크립트를 실행하여 알림을 발송한다.
- 여러 PR이 있는 경우 D-DAY에 근접한 순서대로 정렬한다.
- approved 상태를 제외한 상태인 리뷰어는 알람을 받고, approved 상태인 리뷰어는 해당 PR의 알람을 받지 않는다.  
- 리뷰어는 가장 최신 상태로 안내한다. 또한 PR 작성자는 제외한다.
- 리뷰어로 지정된 모두가 approved 상태이면 assignees에게 코멘트를 확인하고 머지에 대해 안내한다. 
- 해당 PR에서 수정이 일어났는지 확인하기 위해 생성일과 마지막 수정일을 안내한다. -> 알림이 길어지는 문제, 자신이 리뷰 후에 수정된 것인지 여전히 판단하기 힘들다는 의견 반영하여 삭제.

알림 예시 (초기 버전)
```
🍀 [FE] 오늘의 PR 리뷰 목록 🍀

마감일: [D-0] 
제목: [REFACTOR]: 로그인 이슈 해결
현황: @마루(requested changes), @포메(comment), @썬데이(not started)
생성일: 2024-11-08 10:00:00
마지막 수정: 2024-11-10 15:20:00
링크: https://github.com/owner/repo/pull/12345

마감일: [D-0] 
제목: [REFACTOR]: 쿠키 이슈 해결
현황: @마루(approved), @포메(approved)
@썬데이, 모든 리뷰어의 승인 완료! 코멘트를 확인 후 머지해 주세요 🚀
생성일: 2024-11-08 10:00:00
마지막 수정: 2024-11-10 15:20:00
링크: https://github.com/owner/repo/pull/12345

마감일: [D-1] 
제목: [FEAT]: 회원가입 기능
현황: @포메(not started), @마루(comment), 썬데이(approved)
생성일: 2024-11-08 10:00:00
마지막 수정: 2024-11-10 15:20:00
링크: https://github.com/owner/repo/pull/12346
```

알람 예시 (피드백 및 오류 수정 후 최종 버전)
![image](https://github.com/user-attachments/assets/6d708d85-baa2-452f-b25f-4551007980a6)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
늦은 시간이라 알람 보내기 그래서 일단 PR만 올려 둡니다! 낮에 제대로 동작하는지 테스트 해볼게요 ㅎㅎ