### PR TITLE
[FEAT] 사용자 피드백을 반영하여 게임 화면에서 멤버별 투표 현황 보여주기

### DIFF
--- a/frontend/src/apis/balanceContent.ts
+++ b/frontend/src/apis/balanceContent.ts
@@ -21,6 +21,8 @@ interface myGameStatusParams {
 
 interface VoteIsFinished {
   isFinished: boolean;
+  memberCount: number;
+  voteCount: number;
 }
 
 interface MatchingResultParams {

--- a/frontend/src/constants/url.ts
+++ b/frontend/src/constants/url.ts
@@ -1,5 +1,3 @@
-import { getUserInfo } from '@/apis/room';
-
 const BASE_URL = process.env.API_BASE_URL;
 
 export const API_URL = {

--- a/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.styled.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.styled.ts
@@ -10,9 +10,11 @@ export const gameVoteStatusLayout = css`
   height: 4rem;
 `;
 
-export const voteStatusMessage = css`
+export const voteStatusMessage = (theme: Theme, isPending: boolean) => css`
   font-weight: bold;
   font-size: 1.6rem;
+  opacity: ${isPending ? theme.opacity.invisible : theme.opacity.default};
+  transition: 1s;
 `;
 
 export const voteAnnounceMessage = (theme: Theme) => css`

--- a/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.styled.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.styled.ts
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import type { Theme } from '@emotion/react';
+
+export const gameVoteStatusLayout = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.2rem;
+  height: 4rem;
+`;
+
+export const voteStatusMessage = css`
+  font-weight: bold;
+  font-size: 1.6rem;
+`;
+
+export const voteAnnounceMessage = (theme: Theme) => css`
+  color: ${theme.color.gray500};
+  font-weight: bold;
+  font-size: 1.2rem;
+`;

--- a/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
@@ -11,7 +11,7 @@ interface GameVoteStatusContainerProps {
 }
 
 const GameVoteStatusContainer = ({ contentId, isFetching }: GameVoteStatusContainerProps) => {
-  const { voteCount, memberCount } = useVoteIsFinished({
+  const { voteCount, memberCount, isPending } = useVoteIsFinished({
     contentId,
     isFetching,
   });
@@ -20,7 +20,7 @@ const GameVoteStatusContainer = ({ contentId, isFetching }: GameVoteStatusContai
 
   return (
     <div css={gameVoteStatusLayout}>
-      <span css={voteStatusMessage}>{voteStatusText}</span>
+      <span css={(theme) => voteStatusMessage(theme, isPending)}>{voteStatusText}</span>
       <span css={voteAnnounceMessage}>“모두 선택하면 빠르게 결과를 확인할 수 있어요”</span>
     </div>
   );

--- a/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
@@ -1,0 +1,29 @@
+import {
+  gameVoteStatusLayout,
+  voteStatusMessage,
+  voteAnnounceMessage,
+} from './GameVoteStatusContainer.styled';
+import useVoteIsFinished from '../hooks/useVoteIsFinished';
+
+interface GameVoteStatusContainerProps {
+  contentId: number;
+  isFetching: boolean;
+}
+
+const GameVoteStatusContainer = ({ contentId, isFetching }: GameVoteStatusContainerProps) => {
+  const { voteCount, memberCount } = useVoteIsFinished({
+    contentId,
+    isFetching,
+  });
+
+  const voteStatusText = `${memberCount || 0}명 중 ${voteCount || 0}명이 투표했어요!`;
+
+  return (
+    <div css={gameVoteStatusLayout}>
+      <span css={voteStatusMessage}>{voteStatusText}</span>
+      <span css={voteAnnounceMessage}>“모두 선택하면 빠르게 결과를 확인할 수 있어요”</span>
+    </div>
+  );
+};
+
+export default GameVoteStatusContainer;

--- a/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/GameVoteStatusContainer/GameVoteStatusContainer.tsx
@@ -16,7 +16,7 @@ const GameVoteStatusContainer = ({ contentId, isFetching }: GameVoteStatusContai
     isFetching,
   });
 
-  const voteStatusText = `${memberCount || 0}명 중 ${voteCount || 0}명이 투표했어요!`;
+  const voteStatusText = `${memberCount ?? 0}명 중 ${voteCount ?? 0}명이 투표했어요!`;
 
   return (
     <div css={gameVoteStatusLayout}>

--- a/frontend/src/pages/GamePage/components/SelectContainer/SelectContainer.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/SelectContainer.tsx
@@ -1,18 +1,27 @@
 import { useParams } from 'react-router-dom';
 
 import useSelectOption from './hooks/useSelectOption';
+import useVoteIsFinished from './hooks/useVoteIsFinished';
 import { selectContainerLayout, selectSection } from './SelectContainer.styled';
 import SelectOption from './SelectOption/SelectOption';
 import Timer from './Timer/Timer';
 import SelectButton from '../SelectButton/SelectButton';
 
 import useBalanceContentQuery from '@/hooks/useBalanceContentQuery';
+import { Theme } from '@/styles/Theme';
 
 const SelectContainer = () => {
   const { roomId } = useParams();
-  const { balanceContent } = useBalanceContentQuery(Number(roomId));
+  const { balanceContent, isFetching } = useBalanceContentQuery(Number(roomId));
   const { selectedOption, handleClickOption, completeSelection, cancelSelection } =
     useSelectOption();
+
+  const { voteCount, memberCount } = useVoteIsFinished({
+    contentId: balanceContent.contentId,
+    isFetching,
+  });
+
+  const voteText = `${memberCount || 0}명 중 ${voteCount || 0}명이 투표했어요!`;
 
   return (
     <div css={selectContainerLayout}>
@@ -34,6 +43,13 @@ const SelectContainer = () => {
           handleClickOption={handleClickOption}
         />
       </section>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center' }}>
+        <span style={{ fontSize: 16, fontWeight: 'bold' }}>{voteText}</span>
+        <span style={{ fontSize: 12, fontWeight: 'bold', color: Theme.color.gray500 }}>
+          “모두 선택하면 빠르게 결과를 확인할 수 있어요”
+        </span>
+      </div>
+
       <SelectButton
         contentId={balanceContent.contentId}
         selectedOption={selectedOption}

--- a/frontend/src/pages/GamePage/components/SelectContainer/SelectContainer.tsx
+++ b/frontend/src/pages/GamePage/components/SelectContainer/SelectContainer.tsx
@@ -1,27 +1,19 @@
 import { useParams } from 'react-router-dom';
 
+import GameVoteStatusContainer from './GameVoteStatusContainer/GameVoteStatusContainer';
 import useSelectOption from './hooks/useSelectOption';
-import useVoteIsFinished from './hooks/useVoteIsFinished';
 import { selectContainerLayout, selectSection } from './SelectContainer.styled';
 import SelectOption from './SelectOption/SelectOption';
 import Timer from './Timer/Timer';
 import SelectButton from '../SelectButton/SelectButton';
 
 import useBalanceContentQuery from '@/hooks/useBalanceContentQuery';
-import { Theme } from '@/styles/Theme';
 
 const SelectContainer = () => {
   const { roomId } = useParams();
   const { balanceContent, isFetching } = useBalanceContentQuery(Number(roomId));
   const { selectedOption, handleClickOption, completeSelection, cancelSelection } =
     useSelectOption();
-
-  const { voteCount, memberCount } = useVoteIsFinished({
-    contentId: balanceContent.contentId,
-    isFetching,
-  });
-
-  const voteText = `${memberCount || 0}명 중 ${voteCount || 0}명이 투표했어요!`;
 
   return (
     <div css={selectContainerLayout}>
@@ -43,13 +35,7 @@ const SelectContainer = () => {
           handleClickOption={handleClickOption}
         />
       </section>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center' }}>
-        <span style={{ fontSize: 16, fontWeight: 'bold' }}>{voteText}</span>
-        <span style={{ fontSize: 12, fontWeight: 'bold', color: Theme.color.gray500 }}>
-          “모두 선택하면 빠르게 결과를 확인할 수 있어요”
-        </span>
-      </div>
-
+      <GameVoteStatusContainer contentId={balanceContent.contentId} isFetching={isFetching} />
       <SelectButton
         contentId={balanceContent.contentId}
         selectedOption={selectedOption}

--- a/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinished.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinished.ts
@@ -13,7 +13,7 @@ interface UseRoundIsFinishedProps {
 const useVoteIsFinished = ({ contentId, isFetching }: UseRoundIsFinishedProps) => {
   const navigate = useNavigate();
   const { roomId } = useParams();
-  const { isFinished } = useRoundIsFinishedQuery({
+  const { isFinished, memberCount, voteCount } = useRoundIsFinishedQuery({
     contentId,
     enabled: !!contentId && !isFetching,
   });
@@ -24,7 +24,7 @@ const useVoteIsFinished = ({ contentId, isFetching }: UseRoundIsFinishedProps) =
     }
   }, [isFinished, navigate, roomId, isFetching]);
 
-  return { isFinished };
+  return { memberCount, voteCount };
 };
 
 export default useVoteIsFinished;

--- a/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinished.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinished.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import useRoundIsFinishedQuery from './useVoteIsFinishedQuery';
+import useVoteIsFinishedQuery from './useVoteIsFinishedQuery';
 
 import { ROUTES } from '@/constants/routes';
 
@@ -13,7 +13,7 @@ interface UseRoundIsFinishedProps {
 const useVoteIsFinished = ({ contentId, isFetching }: UseRoundIsFinishedProps) => {
   const navigate = useNavigate();
   const { roomId } = useParams();
-  const { isFinished, memberCount, voteCount } = useRoundIsFinishedQuery({
+  const { isFinished, memberCount, voteCount, isPending } = useVoteIsFinishedQuery({
     contentId,
     enabled: !!contentId && !isFetching,
   });
@@ -24,7 +24,7 @@ const useVoteIsFinished = ({ contentId, isFetching }: UseRoundIsFinishedProps) =
     }
   }, [isFinished, navigate, roomId, isFetching]);
 
-  return { memberCount, voteCount };
+  return { memberCount, voteCount, isPending };
 };
 
 export default useVoteIsFinished;

--- a/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinishedQuery.ts
+++ b/frontend/src/pages/GamePage/components/SelectContainer/hooks/useVoteIsFinishedQuery.ts
@@ -33,7 +33,12 @@ const useVoteIsFinishedQuery = ({ contentId, enabled }: UseVoteIsFinishedQueryPr
     gcTime: 0,
   });
 
-  return { ...voteIsFinishedQuery, isFinished: voteIsFinishedQuery.data?.isFinished };
+  return {
+    ...voteIsFinishedQuery,
+    isFinished: voteIsFinishedQuery.data?.isFinished,
+    memberCount: voteIsFinishedQuery.data?.memberCount,
+    voteCount: voteIsFinishedQuery.data?.voteCount,
+  };
 };
 
 export default useVoteIsFinishedQuery;

--- a/frontend/src/pages/ReadyPage/components/StartButtonContainer/hooks/useCountdown.ts
+++ b/frontend/src/pages/ReadyPage/components/StartButtonContainer/hooks/useCountdown.ts
@@ -17,7 +17,7 @@ const useCountdown = ({ isGameStart }: UseCountdownProps) => {
   };
 
   const goToGame = () => {
-    navigate(ROUTES.game(Number(roomId)));
+    navigate(ROUTES.game(Number(roomId)), { replace: true });
   };
 
   useEffect(() => {

--- a/frontend/src/styles/Theme.ts
+++ b/frontend/src/styles/Theme.ts
@@ -61,7 +61,7 @@ const opacity = {
   invisible: 0,
   disabled: 0.6,
   default: 1,
-};
+} as const;
 
 export const Theme = {
   color,

--- a/frontend/src/styles/emotion.d.ts
+++ b/frontend/src/styles/emotion.d.ts
@@ -1,7 +1,8 @@
 import '@emotion/react';
+import { Theme } from './Theme';
+
+type ExtendedTheme = typeof Theme;
 
 declare module '@emotion/react' {
-  export interface Theme {
-    color: { [key: string]: string };
-  }
+  export interface Theme extends ExtendedTheme {}
 }


### PR DESCRIPTION
## Issue Number


## As-Is
<!-- 문제 상황 정의 -->
- 게임 화면 중 현재 투표 상태를 알았으면 좋겠다는 피드백이 있었음
- 선택을 누르지 않아도 선택이 되도록 이미 구현이 되어있는데, 구현을 해달라는 피드백이 있었음

## To-Be
<!-- 변경 사항 -->
- 게임 화면에서 멤버별 투표 여부를 API Response에 추가하여 누가 투표했는지 확인
- 버튼에 추가하는 대신 빈 공간에 `"0명 중 0명이 투표했어요!"` 텍스트로 **현재 투표 상태 알려주기**
  - 기획 변경 이유(1): 버튼에 선택 (0/1 명) 으로 두려고 했으나, 서비스를 잘 모르는 사람 입장에선 이해하기 어렵다고 판단
  - 기획 변경 이유(2): 실제로 팀원이 아닌 사람한테 물어봤을 때 설명없이 이해하기 어려웠다고 하여 변경

- 사용자 입장에선 선택된 옵션으로 투표된다는 기능이 있는걸 모르고, 꼭 선택을 눌러야된다고 생각할 것 같다.
  - 모두 투표를 완료하면 빠르게 투표가 종료된다는 텍스트를 추가하여 사용자에게 알린다.
 
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

|❌ before | ✅ after |
|:-:|:-:|
|<img src="https://github.com/user-attachments/assets/0bace0a1-a090-45cd-9067-f57990986ff8">|<img src="https://github.com/user-attachments/assets/7f40dc46-4b52-4435-84a5-1d47c2ffae3c">|


## (Optional) Additional Description

### "0명 중 0명 선택했어요!" 에 transition 적용

게임 폴링 API 응답값으로 투표 인원과 전체 인원을 가져옵니다. 그런데 네트워크가 느릴 경우를 대비하여 방어 코드를 작성해야 합니다.

근데 "0명 중 0명", "-명 중 -명", "로딩중" 등으로 하려고 했지만 응답이 느리다면 오히려 정보에 의해 혼란스러울 수 있다고 느꼈습니다! 그래서 `느린 네트워크 환경 고려` + `사용자가 해당 정보가 궁금한 시점은 질문과 옵션을 어느정도 읽은 후` 라고 생각해서 응답이 도착한 후 opacity와 transition을 통해 나타냈습니다.

|✅ transition + opacity |
|:-:|
|<video width="200" height="300" src="https://github.com/user-attachments/assets/497eb072-1d8d-4b2e-8375-8f978c4d3b5d" />|


## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/