### PR TITLE
[FIX] 프론트엔드 코드 리뷰 리마인더 및 Discord 알림 수정

### DIFF
--- a/.github/workflows/fe-d-n-label-automation.yml
+++ b/.github/workflows/fe-d-n-label-automation.yml
@@ -2,7 +2,7 @@ name: FE PR D-n 라벨 수정 자동화
 
 on:
   schedule:
-    - cron: "0 15 * * *" # 매일 밤 12시 실행
+    - cron: '10 15 * * *' # 매일 밤 12시 10분 실행
   workflow_dispatch: # 수동 실행 허용
 
 jobs:

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -102,15 +102,23 @@ jobs:
                   const notStartedReviewers = requestedReviewers.filter(
                     reviewer => !reviewStates.has(reviewer) && reviewer !== pr.user.login // PR 작성자 제외
                   );
+                  console.log(notStartedReviewers, '리뷰를 시작하지 않은 리뷰어')
+                  
                   const notStartedMentions = notStartedReviewers.map(reviewer => {
                     return `<@${discordMentions[reviewer]}>(X)`;
                   });
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
+                  console.log(reviewStates, '모든 리뷰 상태 확인');
                   const allReviewersApproved = requestedReviewers.every(
-                    reviewer => reviewStates.get(reviewer) === 'APPROVED'
+                    (reviewer) => {
+                        reviewStates.get(reviewer) === 'APPROVED'
+                        console.log(reviewer, reviewStates.get(reviewer))
+                      }
                   );
+                  console.log(allReviewersApproved, '모든 리뷰어가 어프루브 상태인가?')
+
                   const noPendingReviews = notStartedReviewers.length === 0;
 
                   // 모든 리뷰어가 APPROVED 상태이고 리뷰를 시작하지 않은 리뷰어가 없는 경우
@@ -129,7 +137,7 @@ jobs:
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                  content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}`,
+                  content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}\n\n`,
                   allowed_mentions: {
                     parse: ["users"], // 멘션 가능한 사용자만 허용
                   },

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -1,9 +1,6 @@
 name: FE Review Reminder for Discord
 
 on:
-  pull_request:
-    branches:
-      - develop
   schedule:
     - cron: '10 1 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 10시 10분에 실행
   workflow_dispatch:
@@ -115,7 +112,7 @@ jobs:
 
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
-                  console.log(reviewStates, '모든 리뷰 상태 확인');
+                  console.log(reviewStates, '현재 리뷰 상태 확인');
                   console.log(requestedReviewers, '요청된 리뷰어 확인');
                   const allReviewersApproved = requestedReviewers.every(
                     reviewer => reviewStates.get(reviewer) === 'APPROVED'
@@ -136,7 +133,7 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-              /* const response = await fetch(process.env.DISCORD_WEBHOOK, {
+              const response = await fetch(process.env.DISCORD_WEBHOOK, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({
@@ -147,7 +144,6 @@ jobs:
                   }),
                 });
                 console.log('Response status:', response.status);
-                */
             } catch (error) {
               console.error('Error processing FE PR reminders:', error.message);
               throw error; // 워크플로우 실패 상태 반환

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -75,7 +75,9 @@ jobs:
               const messages = await Promise.all(
                 fePrs.map(async pr => {
                   const reviews = await getReviews(owner, repo, pr.number);
+                  console.log(pr.requested_reviewers, 'requested_reviewers')
                   const requestedReviewers = pr.requested_reviewers.map(r => r.login);
+                  pr.requested_reviewers.map((r) => console.log(r, r.login))
 
                   // 리뷰 상태를 관리하는 Map 객체 생성
                   const reviewStates = new Map();
@@ -144,8 +146,8 @@ jobs:
                     },
                   }),
                 });
-               */
-              console.log('Response status:', response.status);
+                console.log('Response status:', response.status);
+                */
             } catch (error) {
               console.error('Error processing FE PR reminders:', error.message);
               throw error; // 워크플로우 실패 상태 반환

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -74,6 +74,7 @@ jobs:
 
               const messages = await Promise.all(
                 fePrs.map(async pr => {
+                  console.log(pr, 'pr')
                   const reviews = await getReviews(owner, repo, pr.number);
                   console.log(pr.requested_reviewers, 'requested_reviewers')
                   const requestedReviewers = pr.requested_reviewers.map(r => r.login);

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -114,8 +114,9 @@ jobs:
                   const reviewStatusMessage = [...reviewStatuses, ...notStartedMentions];
 
                   console.log(reviewStates, '모든 리뷰 상태 확인');
+                  console.log(requestedReviewers, '요청된 리뷰어 확인');
                   const allReviewersApproved = requestedReviewers.every(
-                    (reviewer) => return reviewStates.get(reviewer) === 'APPROVED'
+                    reviewer => reviewStates.get(reviewer) === 'APPROVED'
                   );
                   console.log(allReviewersApproved, '모든 리뷰어가 어프루브 상태인가?')
 
@@ -133,19 +134,19 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-              const response = await fetch(process.env.DISCORD_WEBHOOK, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}\n\n`,
-                  allowed_mentions: {
-                    parse: ["users"], // 멘션 가능한 사용자만 허용
-                  },
-                }),
-              });
+            #   const response = await fetch(process.env.DISCORD_WEBHOOK, {
+            #     method: 'POST',
+            #     headers: { 'Content-Type': 'application/json' },
+            #     body: JSON.stringify({
+            #       content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}\n\n`,
+            #       allowed_mentions: {
+            #         parse: ["users"], // 멘션 가능한 사용자만 허용
+            #       },
+            #     }),
+            #   });
 
-              console.log('Response status:', response.status);
-            } catch (error) {
-              console.error('Error processing FE PR reminders:', error.message);
-              throw error; // 워크플로우 실패 상태 반환
-            }
+            #   console.log('Response status:', response.status);
+            # } catch (error) {
+            #   console.error('Error processing FE PR reminders:', error.message);
+            #   throw error; // 워크플로우 실패 상태 반환
+            # }

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -59,7 +59,7 @@ jobs:
                   return {
                     ...pr,
                     urgency,
-                    dLabelName: dLabel?.name || 'D-unknown',
+                    dLabelName: dLabel?.name || 'D-3',
                     updatedAt: pr.updated_at,
                     createdAt: pr.created_at,
                   };

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -146,7 +146,7 @@ jobs:
             #   });
 
             #   console.log('Response status:', response.status);
-            # } catch (error) {
-            #   console.error('Error processing FE PR reminders:', error.message);
-            #   throw error; // 워크플로우 실패 상태 반환
-            # }
+            } catch (error) {
+              console.error('Error processing FE PR reminders:', error.message);
+              throw error; // 워크플로우 실패 상태 반환
+            }

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -1,9 +1,6 @@
 name: FE Review Reminder for Discord
 
 on:
-  pull_request:
-    branches:
-      - develop
   schedule:
     - cron: '10 1 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 10시 10분에 실행
   workflow_dispatch:

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -1,6 +1,9 @@
 name: FE Review Reminder for Discord
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
     - cron: '10 1 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 10시 10분에 실행
   workflow_dispatch:

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -134,18 +134,18 @@ jobs:
               );
 
               // 최종 메시지 Discord에 전송
-            #   const response = await fetch(process.env.DISCORD_WEBHOOK, {
-            #     method: 'POST',
-            #     headers: { 'Content-Type': 'application/json' },
-            #     body: JSON.stringify({
-            #       content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}\n\n`,
-            #       allowed_mentions: {
-            #         parse: ["users"], // 멘션 가능한 사용자만 허용
-            #       },
-            #     }),
-            #   });
-
-            #   console.log('Response status:', response.status);
+              /* const response = await fetch(process.env.DISCORD_WEBHOOK, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    content: `🍀 [FE] 리뷰가 필요한 PR 목록 🍀\n\n${messages.join('\n\n')}\n\n`,
+                    allowed_mentions: {
+                      parse: ["users"], // 멘션 가능한 사용자만 허용
+                    },
+                  }),
+                });
+               */
+              console.log('Response status:', response.status);
             } catch (error) {
               console.error('Error processing FE PR reminders:', error.message);
               throw error; // 워크플로우 실패 상태 반환

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
   schedule:
-    - cron: '0 2 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 11시에 실행
+    - cron: '10 1 * * 1-5' # 매주 월요일부터 금요일까지, 한국 시간 오전 10시 10분에 실행
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -76,9 +76,9 @@ jobs:
                 fePrs.map(async pr => {
                   console.log(pr, 'pr')
                   const reviews = await getReviews(owner, repo, pr.number);
+                  console.log(reviews, 'reviews');
                   console.log(pr.requested_reviewers, 'requested_reviewers')
-                  const requestedReviewers = pr.requested_reviewers.map(r => r.login);
-                  pr.requested_reviewers.map((r) => console.log(r, r.login))
+                  const requestedReviewers = ['useon', 'novice0840', 'rbgksqkr'];
 
                   // 리뷰 상태를 관리하는 Map 객체 생성
                   const reviewStates = new Map();

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -32,6 +32,8 @@ jobs:
               'rbgksqkr': '마루',
             };
 
+            const feReviewers = ['useon', 'novice0840', 'rbgksqkr']
+
             async function getReviews(owner, repo, prNumber) {
               // 특정 PR의 리뷰 상태 가져오기
               const reviews = await github.rest.pulls.listReviews({
@@ -74,11 +76,8 @@ jobs:
 
               const messages = await Promise.all(
                 fePrs.map(async pr => {
-                  console.log(pr, 'pr')
                   const reviews = await getReviews(owner, repo, pr.number);
-                  console.log(reviews, 'reviews');
-                  console.log(pr.requested_reviewers, 'requested_reviewers')
-                  const requestedReviewers = ['useon', 'novice0840', 'rbgksqkr'];
+                  const requestedReviewers = feReviewers.filter((reviewer) => reviewer !== pr.user.login) // PR 작성자 제외
 
                   // 리뷰 상태를 관리하는 Map 객체 생성
                   const reviewStates = new Map();
@@ -106,7 +105,7 @@ jobs:
 
                   // 리뷰를 시작하지 않은 리뷰어 추가
                   const notStartedReviewers = requestedReviewers.filter(
-                    reviewer => !reviewStates.has(reviewer) && reviewer !== pr.user.login // PR 작성자 제외
+                    reviewer => !reviewStates.has(reviewer)
                   );
                   console.log(notStartedReviewers, '리뷰를 시작하지 않은 리뷰어')
                   

--- a/.github/workflows/fe-review-reminder.yml
+++ b/.github/workflows/fe-review-reminder.yml
@@ -115,10 +115,7 @@ jobs:
 
                   console.log(reviewStates, '모든 리뷰 상태 확인');
                   const allReviewersApproved = requestedReviewers.every(
-                    (reviewer) => {
-                        reviewStates.get(reviewer) === 'APPROVED'
-                        console.log(reviewer, reviewStates.get(reviewer))
-                      }
+                    (reviewer) => return reviewStates.get(reviewer) === 'APPROVED'
                   );
                   console.log(allReviewersApproved, '모든 리뷰어가 어프루브 상태인가?')
 


### PR DESCRIPTION
## Issue Number
#432 

## As-Is
<!-- 문제 상황 정의 -->
리마인더 스크립트에서 여러 수정이 필요했고, 이유와 변경 사항은 아래에 설명해 두었습니다. 

## To-Be
<!-- 변경 사항 -->
- [x] 확인을 위해 넣어두었던 PR이 열리면 알람이 오도록 하는 코드 삭제
- [x] 라벨을 자동으로 달아주는 스크립트가 돌고나서 PR이 올라오는 경우 D-unknown으로 알림이 오는 문제 D-3으로 수정
- [x] github action의 schedule이 한 시간이나 딜레이가 되어 시간을 오전 10시 10분으로 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
![image](https://github.com/user-attachments/assets/fbc39186-9f70-4f14-bf82-8a38c67e7b55)
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
공식 문서에 따르면 정각에는 과부화가 발생할 수 있다고 하여 11시 정각에 실행되었던 스크립트를 10시 10분으로 수정하였습니다 ! 딜레이 문제가 사라지는 지는 머지 후에 확인할 수 있을 것 같아요 🥹