### PR TITLE
[REFACTOR] MySQL에서 카테고리를 ENUM 대신 VARCHAR(20)으로 관리

### DIFF
--- a/backend/src/main/java/ddangkong/domain/balance/content/BalanceContent.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/BalanceContent.java
@@ -2,14 +2,14 @@ package ddangkong.domain.balance.content;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,8 +20,8 @@ public class BalanceContent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, columnDefinition = "VARCHAR(20)")
     private Category category;
 
     @Column(nullable = false)

--- a/backend/src/main/java/ddangkong/domain/balance/content/BalanceContent.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/BalanceContent.java
@@ -2,14 +2,14 @@ package ddangkong.domain.balance.content;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,8 +20,8 @@ public class BalanceContent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
     private Category category;
 
     @Column(nullable = false)

--- a/backend/src/main/java/ddangkong/domain/balance/content/Category.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/Category.java
@@ -10,7 +10,7 @@ public enum Category {
     IF("만약에"),
     MBTI("MBTI"),
     FOOD("음식"),
-    DEVELOPER("개발"),
+    DEVELOP("개발"),
     ;
 
     private static final List<Category> CATEGORIES = Arrays.stream(Category.values()).toList();

--- a/backend/src/main/java/ddangkong/domain/balance/content/Category.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/Category.java
@@ -10,7 +10,7 @@ public enum Category {
     IF("만약에"),
     MBTI("MBTI"),
     FOOD("음식"),
-    DEVELOPER("개발자"),
+    DEVELOPER("개발"),
     ;
 
     private static final List<Category> CATEGORIES = Arrays.stream(Category.values()).toList();

--- a/backend/src/main/java/ddangkong/domain/balance/content/Category.java
+++ b/backend/src/main/java/ddangkong/domain/balance/content/Category.java
@@ -10,6 +10,7 @@ public enum Category {
     IF("만약에"),
     MBTI("MBTI"),
     FOOD("음식"),
+    DEVELOPER("개발자"),
     ;
 
     private static final List<Category> CATEGORIES = Arrays.stream(Category.values()).toList();

--- a/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
@@ -5,13 +5,13 @@ import ddangkong.exception.room.InvalidRangeTotalRoundException;
 import ddangkong.exception.room.InvalidTimeLimitException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Getter
 @Embeddable
@@ -33,8 +33,8 @@ public class RoomSetting {
     @Column(nullable = false)
     private int timeLimit;
 
-    @Column(nullable = false, length = 20)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, columnDefinition = "VARCHAR(20)")
     private Category category;
 
     public static RoomSetting createNewRoomSetting() {

--- a/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
+++ b/backend/src/main/java/ddangkong/domain/room/RoomSetting.java
@@ -5,13 +5,13 @@ import ddangkong.exception.room.InvalidRangeTotalRoundException;
 import ddangkong.exception.room.InvalidTimeLimitException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Getter
 @Embeddable
@@ -19,11 +19,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomSetting {
 
-    private static final int DEFAULT_TOTAL_ROUND = 5;
     private static final int MIN_TOTAL_ROUND = 3;
     private static final int MAX_TOTAL_ROUND = 10;
     private static final List<Integer> ALLOWED_TIME_LIMIT = List.of(10_000, 15_000, 30_000, 60_000);
+
+    private static final int DEFAULT_TOTAL_ROUND = 5;
     private static final int DEFAULT_TIME_LIMIT_MSEC = 10_000;
+    private static final Category DEFAULT_CATEGORY = Category.IF;
 
     @Column(nullable = false)
     private int totalRound;
@@ -31,12 +33,12 @@ public class RoomSetting {
     @Column(nullable = false)
     private int timeLimit;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
     private Category category;
 
     public static RoomSetting createNewRoomSetting() {
-        return new RoomSetting(DEFAULT_TOTAL_ROUND, DEFAULT_TIME_LIMIT_MSEC, Category.IF);
+        return new RoomSetting(DEFAULT_TOTAL_ROUND, DEFAULT_TIME_LIMIT_MSEC, DEFAULT_CATEGORY);
     }
 
     public RoomSetting(int totalRound, int timeLimit, Category category) {


### PR DESCRIPTION
## Issue Number
Closed #435 

## As-Is
<!-- 문제 상황 정의 -->

- MySQL에서 카테고리를 ENUM으로 관리하다보니, 카테고리가 추가될 때마다 MySQL에서 관리하는 ENUM 필드의 허용 값을 변경해주어야 함

## To-Be
<!-- 변경 사항 -->

- MySQL에서 카테고리를 ENUM 대신 VARCHAR(20)으로 관리
  - Application에서는 java enum으로 관리
- 개발자 카테고리 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/2a3e75d5-3dd5-4c8b-b0bc-24b174221433)
![image](https://github.com/user-attachments/assets/49ca5dd2-78b5-40bd-9663-3bad40ac80c3)

## (Optional) Additional Description

- 문서화 추가 예정
