### PR TITLE
[FIX] 방장이 자신의 방이 아닌 다른 방의 방장 권한을 얻게 되는 버그 수정 

### DIFF
--- a/frontend/src/hooks/useGetUserInfo.ts
+++ b/frontend/src/hooks/useGetUserInfo.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import { getUserInfo } from '@/apis/room';
 import { QUERY_KEYS } from '@/constants/queryKeys';
@@ -9,12 +9,16 @@ const USER_INFO_STALE_TIME = 2 * 60 * 60 * 1000;
 
 const useGetUserInfo = (): RoomAndMember => {
   const { roomId } = useParams();
-
+  const navigate = useNavigate();
   const { data } = useQuery({
     queryKey: [QUERY_KEYS.getUserInfo, roomId],
     queryFn: getUserInfo,
     staleTime: USER_INFO_STALE_TIME,
   });
+
+  if (Number(roomId) !== data?.roomId) {
+    navigate('/', { replace: true });
+  }
 
   return {
     roomId: data?.roomId || 0,


### PR DESCRIPTION
## Issue Number

#404 

## As-Is
A 방의 방장이 B 방에 접속시 방장 권한을 얻는 문제 발생

## To-Be
JWT에 담긴 정보에서의 방 번호와 현재 접속한 방 번호를 비교해 일치하지 않는 경우 방장 권한을 주지 않는 방식으로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

방장 권한 확인 시 현재 URL를 확인하는 로직이 추가되어 테스트가 깨지는 문제가 발생 (테스트 환경에서는 URL에 방 번호가 없으므로)
useIsMaster를 mocking하는 방식으로 테스트 코드를 변경함 


## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/

## 🌸 Storybook 배포 주소 

> https://woowacourse-teams.github.io/2024-ddangkong/storybook/