### PR TITLE
[FEAT] 방장 넘기기 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/room.adoc
+++ b/backend/src/docs/asciidoc/room.adoc
@@ -82,6 +82,26 @@ include::{snippets}/room/member/response-fields.adoc[]
 
 '''
 
+=== 방장 변경
+
+==== curl
+
+include::{snippets}/room/passMaster/curl-request.adoc[]
+
+==== request
+
+include::{snippets}/room/passMaster/http-request.adoc[]
+
+include::{snippets}/room/passMaster/path-parameters.adoc[]
+
+include::{snippets}/room/passMaster/request-fields.adoc[]
+
+==== response
+
+include::{snippets}/room/passMaster/http-response.adoc[]
+
+'''
+
 === 방 나가기
 
 ==== curl

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -6,6 +6,7 @@ import ddangkong.aop.cookie.MemberId;
 import ddangkong.aop.logging.Polling;
 import ddangkong.facade.room.RoomFacade;
 import ddangkong.facade.room.dto.InitialRoomResponse;
+import ddangkong.facade.room.dto.PassMasterRequest;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
@@ -69,6 +70,13 @@ public class RoomController {
     public RoomJoinResponse joinRoom(@PathVariable String uuid,
                                      @Valid @RequestBody RoomJoinRequest request) {
         return roomFacade.joinRoom(request.nickname(), uuid);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/balances/rooms/{roomId}/pass-master")
+    public void passMaster(@PathVariable @Positive Long roomId,
+                           @RequestBody @Valid PassMasterRequest request) {
+        roomFacade.passMaster(roomId, request.nextMasterId());
     }
 
     @DeleteCookie

--- a/backend/src/main/java/ddangkong/domain/room/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/room/member/Member.java
@@ -1,6 +1,7 @@
 package ddangkong.domain.room.member;
 
 import ddangkong.domain.room.Room;
+import ddangkong.exception.room.member.AlreadyCommonException;
 import ddangkong.exception.room.member.AlreadyMasterException;
 import ddangkong.exception.room.member.InvalidNicknameException;
 import jakarta.persistence.Column;
@@ -64,6 +65,13 @@ public class Member {
             throw new AlreadyMasterException(id);
         }
         isMaster = true;
+    }
+
+    public void demoteToCommon() {
+        if (isCommon()) {
+            throw new AlreadyCommonException(id);
+        }
+        isMaster = false;
     }
 
     public boolean isSameId(Long id) {

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -30,6 +30,7 @@ public enum ClientErrorCode {
     // Member
     ALREADY_EXIST_MASTER("이미 방장이 존재합니다."),
     ALREADY_MASTER("해당 멤버는 이미 방장입니다. memberId : %d"),
+    ALREADY_COMMON("해당 멤버는 이미 일반 유저입니다. memberId : %d"),
     INVALID_MASTER_CREATION("방에 멤버가 존재하면 방장을 생성할 수 없습니다. 현재 멤버 수: %d"),
     NOT_EXIST_MASTER("방장이 존재하지 않습니다."),
     NOT_EXIST_COMMON("일반 멤버가 존재하지 않습니다."),

--- a/backend/src/main/java/ddangkong/exception/room/member/AlreadyCommonException.java
+++ b/backend/src/main/java/ddangkong/exception/room/member/AlreadyCommonException.java
@@ -1,0 +1,17 @@
+package ddangkong.exception.room.member;
+
+import static ddangkong.exception.ClientErrorCode.ALREADY_COMMON;
+
+import ddangkong.exception.BadRequestException;
+
+public class AlreadyCommonException extends BadRequestException {
+
+    public AlreadyCommonException(Long memberId) {
+        super(ALREADY_COMMON.getMessage().formatted(memberId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ALREADY_COMMON.name();
+    }
+}

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -5,6 +5,7 @@ import ddangkong.domain.room.Room;
 import ddangkong.domain.room.member.Member;
 import ddangkong.domain.room.member.RoomMembers;
 import ddangkong.exception.room.NotFinishedRoomException;
+import ddangkong.exception.room.NotReadyRoomException;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinResponse;
@@ -58,6 +59,17 @@ public class RoomFacade {
         Member member = memberService.getMemberById(memberId);
         Room room = member.getRoom();
         return new RoomMemberResponse(room.getId(), room.getUuid(), new MemberResponse(member));
+    }
+
+    @Transactional
+    public void passMaster(Long roomId, Long nextMasterId) {
+        Room room = roomService.getRoom(roomId);
+        if (room.isAlreadyStart()) {
+            throw new NotReadyRoomException();
+        }
+
+        RoomMembers roomMembers = memberService.findRoomMembers(room);
+        memberService.passMaster(roomMembers, nextMasterId);
     }
 
     @Transactional

--- a/backend/src/main/java/ddangkong/facade/room/dto/PassMasterRequest.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/PassMasterRequest.java
@@ -1,0 +1,6 @@
+package ddangkong.facade.room.dto;
+
+import jakarta.validation.constraints.Positive;
+
+public record PassMasterRequest(@Positive Long nextMasterId) {
+}

--- a/backend/src/main/java/ddangkong/service/room/member/MemberService.java
+++ b/backend/src/main/java/ddangkong/service/room/member/MemberService.java
@@ -75,6 +75,15 @@ public class MemberService {
     }
 
     @Transactional
+    public void passMaster(RoomMembers members, Long nextMasterId) {
+        Member currentMaster = members.getMaster();
+        Member nextMaster = members.getMember(nextMasterId);
+
+        nextMaster.promoteToMaster();
+        currentMaster.demoteToCommon();
+    }
+
+    @Transactional
     public void promoteOtherMember(RoomMembers members) {
         Member commonMember = members.getAnyCommonMember();
         commonMember.promoteToMaster();

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -9,6 +9,7 @@ import ddangkong.domain.room.Room;
 import ddangkong.domain.room.RoomStatus;
 import ddangkong.domain.room.member.Member;
 import ddangkong.facade.room.dto.InitialRoomResponse;
+import ddangkong.facade.room.dto.PassMasterRequest;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
@@ -141,6 +142,56 @@ class RoomControllerTest extends BaseControllerTest {
     }
 
     @Nested
+    class 방장_변경 {
+
+        @Test
+        void 방장의_권한을_다른_멤버에게_넘길_수_있다() {
+            // given
+            Room room = roomFixture.createNotStartedRoom();
+            Member beforeMaster = memberFixture.createMaster(room);
+            Member afterMaster = memberFixture.createCommon(room);
+
+            PassMasterRequest request = new PassMasterRequest(afterMaster.getId());
+
+            // when
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .pathParam("roomId", room.getId())
+                    .body(request)
+                    .when().patch("/api/balances/rooms/{roomId}/pass-master")
+                    .then().log().all()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            // then
+            Member savedBeforeMaster = memberRepository.findById(beforeMaster.getId()).orElseThrow();
+            Member savedAfterMaster = memberRepository.findById(afterMaster.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(savedBeforeMaster.isMaster()).isFalse(),
+                    () -> assertThat(savedAfterMaster.isMaster()).isTrue()
+            );
+        }
+
+        @Test
+        void 게임이_진행중일때는_방장을_변경할_수_없다() {
+            // given
+            Room progressRoom = roomFixture.createProgressRoom();
+            Member master = memberFixture.createMaster(progressRoom);
+            Member newMaster = memberFixture.createCommon(progressRoom);
+
+            PassMasterRequest request = new PassMasterRequest(newMaster.getId());
+
+            // when & then
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .pathParam("roomId", progressRoom.getId())
+                    .body(request)
+                    .when().patch("/api/balances/rooms/{roomId}/pass-master")
+                    .then().log().all()
+                    .statusCode(HttpStatus.BAD_REQUEST.value());
+        }
+    }
+
+    @Nested
     class 방_설정_변경 {
 
         @Test
@@ -167,7 +218,7 @@ class RoomControllerTest extends BaseControllerTest {
                     .then().log().all()
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
-            Room changedRoom = roomRepository.findById(room.getId()).get();
+            Room changedRoom = roomRepository.findById(room.getId()).orElseThrow();
 
             // then
             assertThat(changedRoom.getCategory()).isEqualTo(Category.FOOD);

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -32,6 +32,7 @@ import ddangkong.domain.balance.content.Category;
 import ddangkong.facade.balance.content.BalanceCategoryResponse;
 import ddangkong.facade.room.RoomFacade;
 import ddangkong.facade.room.dto.InitialRoomResponse;
+import ddangkong.facade.room.dto.PassMasterRequest;
 import ddangkong.facade.room.dto.RoomInfoResponse;
 import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
@@ -211,6 +212,35 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                             ),
                             responseCookies(
                                     cookieWithName("test_cookie").description("방 재참여시 사용되는 쿠키")
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    class 방장_교체 {
+
+        private static final String ENDPOINT = "/api/balances/rooms/{roomId}/pass-master";
+
+        @Test
+        void 방장의_권한을_다른_멤버에게_넘긴다() throws Exception {
+            // given
+            Long roomId = 1L;
+            Long nextMasterId = 2L;
+            PassMasterRequest request = new PassMasterRequest(nextMasterId);
+
+            // when & then
+            mockMvc.perform(patch(ENDPOINT, roomId)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isNoContent())
+                    .andDo(document("room/passMaster",
+                            pathParameters(
+                                    parameterWithName("roomId").description("방 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nextMasterId").type(NUMBER).description("새로운 방장 멤버 ID")
                             )
                     ));
         }

--- a/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ddangkong.domain.room.Room;
+import ddangkong.exception.room.member.AlreadyCommonException;
 import ddangkong.exception.room.member.AlreadyMasterException;
 import ddangkong.exception.room.member.InvalidNicknameException;
 import ddangkong.support.fixture.EntityFixtureUtils;
@@ -42,6 +43,34 @@ class MemberTest {
             assertThatThrownBy(() -> master.promoteToMaster())
                     .isExactlyInstanceOf(AlreadyMasterException.class)
                     .hasMessage("해당 멤버는 이미 방장입니다. memberId : 3");
+        }
+    }
+
+    @Nested
+    class 일반_유저로_변경 {
+
+        @Test
+        void 마스터_유저를_일반_유저로_변경할_수_있다() {
+            // given
+            Member master = Member.createMaster("prin", ROOM);
+
+            // when
+            master.demoteToCommon();
+
+            // then
+            assertThat(master.isMaster()).isFalse();
+        }
+
+        @Test
+        void 일반_유저인_경우_예외를_발생한다() {
+            // given
+            Member common = Member.createCommon("prin", ROOM);
+            EntityFixtureUtils.setId(common, 3L);
+
+            // when & then
+            assertThatThrownBy(() -> common.demoteToCommon())
+                    .isExactlyInstanceOf(AlreadyCommonException.class)
+                    .hasMessage("해당 멤버는 이미 일반 유저입니다. memberId : 3");
         }
     }
 

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -16,6 +16,7 @@ import ddangkong.domain.room.balance.roomvote.RoomBalanceVote;
 import ddangkong.domain.room.member.Member;
 import ddangkong.exception.room.NotFinishedRoomException;
 import ddangkong.exception.room.NotFoundRoomException;
+import ddangkong.exception.room.NotReadyRoomException;
 import ddangkong.exception.room.member.InvalidMemberIdException;
 import ddangkong.facade.BaseServiceTest;
 import ddangkong.facade.room.dto.InitialRoomResponse;
@@ -149,6 +150,41 @@ class RoomFacadeTest extends BaseServiceTest {
             // when & then
             assertThatThrownBy(() -> roomFacade.getRoomMemberInfo(notExistMemberId))
                     .isExactlyInstanceOf(InvalidMemberIdException.class);
+        }
+    }
+
+    @Nested
+    class 방_마스터_교체 {
+
+        @Test
+        void 방_마스터를_교체한다() {
+            // given
+            Room room = roomFixture.createNotStartedRoom();
+            Member beforeMaster = memberFixture.createMaster(room);
+            Member afterMaster = memberFixture.createCommon(room);
+
+            // when
+            roomFacade.passMaster(room.getId(), afterMaster.getId());
+
+            // then
+            Member savedBeforeMaster = memberRepository.findById(beforeMaster.getId()).orElseThrow();
+            Member savedAfterMaster = memberRepository.findById(afterMaster.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(savedBeforeMaster.isMaster()).isFalse(),
+                    () -> assertThat(savedAfterMaster.isMaster()).isTrue()
+            );
+        }
+
+        @Test
+        void 방이_진행중인_경우_방_마스터를_교체할_수_없다() {
+            // given
+            Room room = roomFixture.createProgressRoom();
+            Member master = memberFixture.createMaster(room);
+            Member nextMaster = memberFixture.createCommon(room);
+
+            // when & then
+            assertThatThrownBy(() -> roomFacade.passMaster(room.getId(), nextMaster.getId()))
+                    .isExactlyInstanceOf(NotReadyRoomException.class);
         }
     }
 

--- a/backend/src/test/java/ddangkong/service/room/member/MemberServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/room/member/MemberServiceTest.java
@@ -10,6 +10,7 @@ import ddangkong.domain.room.member.Member;
 import ddangkong.domain.room.member.RoomMembers;
 import ddangkong.exception.room.NotReadyRoomException;
 import ddangkong.exception.room.member.AlreadyExistMasterException;
+import ddangkong.exception.room.member.AlreadyMasterException;
 import ddangkong.exception.room.member.ExceedMaxMemberCountException;
 import ddangkong.exception.room.member.InvalidMasterCreationException;
 import ddangkong.exception.room.member.NotExistCommonMemberException;
@@ -157,7 +158,42 @@ class MemberServiceTest extends BaseServiceTest {
     }
 
     @Nested
-    class 방장_넘겨주기 {
+    class 특정_멤버에게_방장_권한_부여 {
+
+        @Test
+        void 일반_멤버에게_방장_권한을_부여한다() {
+            // given
+            Room room = roomFixture.createNotStartedRoom();
+            Member master = memberFixture.createMaster(room);
+            Member common = memberFixture.createCommon(room);
+            RoomMembers roomMembers = new RoomMembers(List.of(master, common));
+
+            // when
+            memberService.passMaster(roomMembers, common.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(master.isMaster()).isFalse(),
+                    () -> assertThat(common.isMaster()).isTrue()
+            );
+        }
+
+        @Test
+        void 이미_방장인_멤버에겐_방장_권한을_다시_부여할_수_없다() {
+            // given
+            Room room = roomFixture.createNotStartedRoom();
+            Member master = memberFixture.createMaster(room);
+            Member common = memberFixture.createCommon(room);
+            RoomMembers roomMembers = new RoomMembers(List.of(master, common));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.passMaster(roomMembers, master.getId()))
+                    .isExactlyInstanceOf(AlreadyMasterException.class);
+        }
+    }
+
+    @Nested
+    class 임의의_다른_멤버에게_방장_권한_부여 {
 
         private Room room;
         private Member master;


### PR DESCRIPTION
## Issue Number
closed #473 

## As-Is
<!-- 문제 상황 정의 -->
- 대기실에서 방장을 다른 사람에게 넘겨주는 기능 필요

## To-Be
<!-- 변경 사항 -->
- 구현 사항
  - 방장 넘기기 도메인 로직 구현
  - 방장 넘기기 API 구현
  - 방장 넘기기 Docs 작성
- 중요 로직
  - `nextMasterId` 가 이미 방장인 경우, 400 에러 발생
  - 방이 READY 상태가 아닌 경우, 400 에러 발생

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/4cab7618-824c-47ca-b7e2-f95316ed583f)

## (Optional) Additional Description
- 오랜만에 PR 쓰니까 진짜 추억 돋는다.
- 일단 타칸 리뷰는 필수적으로 받고, 프린이나 이든 리뷰는 선택적으로 받을께요~
    - 타칸이 빠르게 Approve 하면 그냥 머지 되는겁니다~
