### PR TITLE
[FIX] 방 정보 조회 API (polling)에서 방장이 항상 제일 앞에 있도록 구현

### DIFF
--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomInfoResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomInfoResponse.java
@@ -1,9 +1,11 @@
 package ddangkong.facade.room.dto;
 
 import ddangkong.domain.room.Room;
+import ddangkong.domain.room.member.Member;
 import ddangkong.domain.room.member.RoomMembers;
 import ddangkong.facade.room.member.dto.MasterResponse;
 import ddangkong.facade.room.member.dto.MemberResponse;
+import java.util.Comparator;
 import java.util.List;
 
 public record RoomInfoResponse(
@@ -16,6 +18,7 @@ public record RoomInfoResponse(
     public static RoomInfoResponse create(RoomMembers members, Room room) {
         List<MemberResponse> membersResponse = members.getMembers()
                 .stream()
+                .sorted(Comparator.comparing(Member::isMaster).reversed())
                 .map(MemberResponse::new)
                 .toList();
         RoomSettingResponse roomSettingResponse = new RoomSettingResponse(room);

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -286,6 +286,28 @@ class RoomFacadeTest extends BaseServiceTest {
                     () -> assertThat(actual.master().memberId()).isEqualTo(master.getId())
             );
         }
+
+        @Test
+        void 조회_결과에서_방장이_가장_앞에_위치한다() {
+            // given
+            Room room = roomFixture.createNotStartedRoom();
+            memberFixture.createCommon(1, room);
+            memberFixture.createCommon(2, room);
+            Member master = memberFixture.createMaster(room);
+
+            // when
+            RoomInfoResponse actual = roomFacade.getRoomInfo(room.getId());
+
+            // then
+            List<MemberResponse> members = actual.members();
+            assertAll(
+                    () -> assertThat(members).hasSize(3),
+                    () -> assertThat(members.get(0).memberId()).isEqualTo(master.getId()),
+                    () -> assertThat(members.get(0).isMaster()).isTrue(),
+                    () -> assertThat(members.get(1).isMaster()).isFalse(),
+                    () -> assertThat(members.get(2).isMaster()).isFalse()
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Issue Number
closed #476 

## As-Is
<!-- 문제 상황 정의 -->
- 이전에는 DB 저장 로직, 방장 전달 로직 기능 구현에 의해 방장이 항상 먼저 조회되었음
- '방장 넘기기' 기능이 들어오면서 방장이 맨 위에 있지 않는 경우가 생김

## To-Be
<!-- 변경 사항 -->
- `RoomInfoResponse`의 매핑 로직 중 정렬 기능 추가
- 관련 테스트 케이스 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/8669ba3f-b6b2-4f56-b749-4c400e623f59)

## (Optional) Additional Description
- 간단하게 구현했습니다.
