### PR TITLE
[FEAT] 멤버 정보 요청/응답에 이미지 URL 추가

### DIFF
--- a/backend/scripts/dev/kill-application.sh
+++ b/backend/scripts/dev/kill-application.sh
@@ -1,4 +1,4 @@
-PIDS=$(lsof -t -i:8080)
+PIDS=$(sudo lsof -t -i:8080)
 
 # 프로세스 종료
 if [ -z "$PIDS" ]; then

--- a/backend/scripts/dev/kill-application.sh
+++ b/backend/scripts/dev/kill-application.sh
@@ -1,9 +1,14 @@
 PIDS=$(sudo lsof -t -i:8080)
 
-# 프로세스 종료
 if [ -z "$PIDS" ]; then
   echo "No process is using port 8080."
 else
-  sudo kill -15 $PIDS
-  echo "Killing process with PIDS: $PIDS"
+  for PID in $PIDS; do
+    echo "Attempting to terminate PID: $PID"
+    if sudo kill -15 "$PID"; then
+      echo "Process $PID terminated successfully."
+    else
+      echo "Failed to terminate process $PID."
+    fi
+  done
 fi

--- a/backend/scripts/dev/kill-application.sh
+++ b/backend/scripts/dev/kill-application.sh
@@ -1,9 +1,9 @@
-PID=$(lsof -t -i:8080)
+PIDS=$(lsof -t -i:8080)
 
 # 프로세스 종료
-if [ -z "$PID" ]; then
+if [ -z "$PIDS" ]; then
   echo "No process is using port 8080."
 else
-  sudo kill -15 "$PID"
-  echo "Killing process with PID: $PID"
+  sudo kill -15 $PIDS
+  echo "Killing process with PIDS: $PIDS"
 fi

--- a/backend/scripts/dev/kill-application.sh
+++ b/backend/scripts/dev/kill-application.sh
@@ -4,6 +4,6 @@ PID=$(lsof -t -i:8080)
 if [ -z "$PID" ]; then
   echo "No process is using port 8080."
 else
+  sudo kill -15 "$PID"
   echo "Killing process with PID: $PID"
-  kill -15 "$PID"
 fi

--- a/backend/scripts/dev/replace-new-version.sh
+++ b/backend/scripts/dev/replace-new-version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-PIDS=$(lsof -t -i:8080)
+PIDS=$(sudo lsof -t -i:8080)
 
 # 프로세스 종료
 if [ -z "$PIDS" ]; then
   echo "No process is using port 8080."
 else
   echo "Killing process with PIDS: $PIDS"
-  kill -15 $PIDS
+  sudo kill -15 $PIDS
 
   # 직전 명령(프로세스 종료 명령)이 정상 동작했는지 확인
   if [ $? -eq 0 ]; then

--- a/backend/scripts/dev/replace-new-version.sh
+++ b/backend/scripts/dev/replace-new-version.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-PID=$(lsof -t -i:8080)
+PIDS=$(lsof -t -i:8080)
 
 # 프로세스 종료
-if [ -z "$PID" ]; then
+if [ -z "$PIDS" ]; then
   echo "No process is using port 8080."
 else
-  echo "Killing process with PID: $PID"
-  kill -15 "$PID"
+  echo "Killing process with PIDS: $PIDS"
+  kill -15 $PIDS
 
   # 직전 명령(프로세스 종료 명령)이 정상 동작했는지 확인
   if [ $? -eq 0 ]; then
-    echo "Process $PID terminated successfully."
+    echo "Process $PIDS terminated successfully."
   else
-    echo "Failed to terminate process $PID."
+    echo "Failed to terminate process $PIDS."
   fi
 fi
 

--- a/backend/scripts/dev/replace-new-version.sh
+++ b/backend/scripts/dev/replace-new-version.sh
@@ -6,15 +6,14 @@ PIDS=$(sudo lsof -t -i:8080)
 if [ -z "$PIDS" ]; then
   echo "No process is using port 8080."
 else
-  echo "Killing process with PIDS: $PIDS"
-  sudo kill -15 $PIDS
-
-  # 직전 명령(프로세스 종료 명령)이 정상 동작했는지 확인
-  if [ $? -eq 0 ]; then
-    echo "Process $PIDS terminated successfully."
-  else
-    echo "Failed to terminate process $PIDS."
-  fi
+  for PID in $PIDS; do
+    echo "Killing process with PID: $PID"
+    if sudo kill -15 "$PID"; then
+      echo "Process $PID terminated successfully."
+    else
+      echo "Failed to terminate process $PID."
+    fi
+  done
 fi
 
 JAR_FILE=$(ls /home/ddangkong/app/*.jar | head -n 1)

--- a/backend/src/main/java/ddangkong/controller/room/RoomController.java
+++ b/backend/src/main/java/ddangkong/controller/room/RoomController.java
@@ -43,7 +43,7 @@ public class RoomController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/balances/rooms")
     public RoomJoinResponse createRoom(@Valid @RequestBody RoomJoinRequest request) {
-        return roomFacade.createRoom(request.nickname());
+        return roomFacade.createRoom(request);
     }
 
     @GetMapping("/balances/rooms/member")
@@ -69,7 +69,7 @@ public class RoomController {
     @PostMapping("/balances/rooms/{uuid}/members")
     public RoomJoinResponse joinRoom(@PathVariable String uuid,
                                      @Valid @RequestBody RoomJoinRequest request) {
-        return roomFacade.joinRoom(request.nickname(), uuid);
+        return roomFacade.joinRoom(request, uuid);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/backend/src/main/java/ddangkong/domain/room/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/room/member/Member.java
@@ -33,7 +33,7 @@ public class Member {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 511)
     private String imageUrl;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)

--- a/backend/src/main/java/ddangkong/domain/room/member/Member.java
+++ b/backend/src/main/java/ddangkong/domain/room/member/Member.java
@@ -1,6 +1,7 @@
 package ddangkong.domain.room.member;
 
 import ddangkong.domain.room.Room;
+import ddangkong.exception.room.InvalidImageUrlException;
 import ddangkong.exception.room.member.AlreadyCommonException;
 import ddangkong.exception.room.member.AlreadyMasterException;
 import ddangkong.exception.room.member.InvalidNicknameException;
@@ -32,6 +33,9 @@ public class Member {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(nullable = false)
+    private String imageUrl;
+
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", nullable = false)
     private Room room;
@@ -39,9 +43,12 @@ public class Member {
     @Column(nullable = false)
     private boolean isMaster;
 
-    private Member(String nickname, Room room, boolean isMaster) {
+    private Member(String nickname, String imageUrl, Room room, boolean isMaster) {
         validateNickname(nickname);
+        validateImageUrl(imageUrl);
+
         this.nickname = nickname;
+        this.imageUrl = imageUrl;
         this.room = room;
         this.isMaster = isMaster;
     }
@@ -52,12 +59,18 @@ public class Member {
         }
     }
 
-    public static Member createMaster(String nickname, Room room) {
-        return new Member(nickname, room, true);
+    private void validateImageUrl(String imageUrl) {
+        if (Strings.isBlank(imageUrl) || !imageUrl.startsWith("https://")) {
+            throw new InvalidImageUrlException();
+        }
     }
 
-    public static Member createCommon(String nickname, Room room) {
-        return new Member(nickname, room, false);
+    public static Member createMaster(String nickname, String imageUrl, Room room) {
+        return new Member(nickname, imageUrl, room, true);
+    }
+
+    public static Member createCommon(String nickname, String imageUrl, Room room) {
+        return new Member(nickname, imageUrl, room, false);
     }
 
     public void promoteToMaster() {

--- a/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
+++ b/backend/src/main/java/ddangkong/exception/ClientErrorCode.java
@@ -36,6 +36,7 @@ public enum ClientErrorCode {
     EXCEED_MAX_MEMBER_COUNT("방의 최대 인원을 초과했습니다. 현재 멤버 수: %d"),
     NOT_ROOM_MEMBER("방에 존재하지 않는 멤버입니다."),
     INVALID_NICKNAME("닉네임은 공백이어선 안되며 최대 %d글자여야 합니다."),
+    INVALID_IMAGE_URL("이미지 URL 형식이 올바르지 않습니다."),
     INVALID_MEMBER_ID("해당 ID에 일치하는 멤버가 없습니다."),
 
     // RoomContent

--- a/backend/src/main/java/ddangkong/exception/room/InvalidImageUrlException.java
+++ b/backend/src/main/java/ddangkong/exception/room/InvalidImageUrlException.java
@@ -1,0 +1,17 @@
+package ddangkong.exception.room;
+
+import static ddangkong.exception.ClientErrorCode.INVALID_IMAGE_URL;
+
+import ddangkong.exception.BadRequestException;
+
+public class InvalidImageUrlException extends BadRequestException {
+
+    public InvalidImageUrlException() {
+        super(INVALID_IMAGE_URL.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return INVALID_IMAGE_URL.name();
+    }
+}

--- a/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
+++ b/backend/src/main/java/ddangkong/facade/balance/vote/dto/GiveUpVoteMemberResponse.java
@@ -1,18 +1,17 @@
 package ddangkong.facade.balance.vote.dto;
 
 import ddangkong.domain.room.member.Member;
+import ddangkong.facade.room.member.dto.MemberResponse;
 import java.util.List;
 
 public record GiveUpVoteMemberResponse(
-        List<String> members,
+        List<MemberResponse> members,
         int memberCount) {
 
     public static GiveUpVoteMemberResponse create(List<Member> giveUpMembers) {
-        List<String> members = giveUpMembers.stream()
-                .map(Member::getNickname)
+        List<MemberResponse> members = giveUpMembers.stream()
+                .map(MemberResponse::new)
                 .toList();
-        int memberCount = giveUpMembers.size();
-
-        return new GiveUpVoteMemberResponse(members, memberCount);
+        return new GiveUpVoteMemberResponse(members, members.size());
     }
 }

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -44,14 +44,14 @@ public class RoomFacade {
     @Transactional
     public RoomJoinResponse createRoom(RoomJoinRequest request) {
         Room room = roomService.createRoom();
-        Member member = memberService.saveMember(request.toMasterMember(room));
+        Member member = memberService.saveMember(Member.createMaster(request.nickname(), request.imageUrl(), room));
         return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 
     @Transactional
     public RoomJoinResponse joinRoom(RoomJoinRequest request, String uuid) {
         Room room = roomService.getRoomWithLock(uuid);
-        Member member = memberService.saveMember(request.toCommonMember(room));
+        Member member = memberService.saveMember(Member.createCommon(request.nickname(), request.imageUrl(), room));
         return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -8,6 +8,7 @@ import ddangkong.exception.room.NotFinishedRoomException;
 import ddangkong.exception.room.NotReadyRoomException;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
+import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
 import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
@@ -51,6 +52,13 @@ public class RoomFacade {
     public RoomJoinResponse joinRoom(String nickname, String uuid) {
         Room room = roomService.getRoomWithLock(uuid);
         Member member = memberService.saveCommonMember(nickname, room);
+        return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
+    }
+
+    @Transactional
+    public RoomJoinResponse joinRoom(RoomJoinRequest request, String uuid) {
+        Room room = roomService.getRoomWithLock(uuid);
+        Member member = memberService.saveCommonMember(null, room); // TODO : 개선
         return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 

--- a/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
+++ b/backend/src/main/java/ddangkong/facade/room/RoomFacade.java
@@ -42,23 +42,16 @@ public class RoomFacade {
     private final RoomMigrator roomMigrator;
 
     @Transactional
-    public RoomJoinResponse createRoom(String nickname) {
+    public RoomJoinResponse createRoom(RoomJoinRequest request) {
         Room room = roomService.createRoom();
-        Member member = memberService.saveMasterMember(nickname, room);
-        return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
-    }
-
-    @Transactional
-    public RoomJoinResponse joinRoom(String nickname, String uuid) {
-        Room room = roomService.getRoomWithLock(uuid);
-        Member member = memberService.saveCommonMember(nickname, room);
+        Member member = memberService.saveMember(request.toMasterMember(room));
         return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 
     @Transactional
     public RoomJoinResponse joinRoom(RoomJoinRequest request, String uuid) {
         Room room = roomService.getRoomWithLock(uuid);
-        Member member = memberService.saveCommonMember(null, room); // TODO : 개선
+        Member member = memberService.saveMember(request.toCommonMember(room));
         return new RoomJoinResponse(room.getId(), room.getUuid(), new MemberResponse(member));
     }
 

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/OptionRoomBalanceVoteResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/OptionRoomBalanceVoteResponse.java
@@ -2,13 +2,14 @@ package ddangkong.facade.room.balance.roomvote.dto;
 
 import ddangkong.domain.balance.option.BalanceOption;
 import ddangkong.domain.room.balance.roomvote.RoomBalanceVote;
+import ddangkong.facade.room.member.dto.MemberResponse;
 import ddangkong.util.PercentageCalculator;
 import java.util.List;
 
 public record OptionRoomBalanceVoteResponse(
         Long optionId,
         String name,
-        List<String> members,
+        List<MemberResponse> members,
         int memberCount,
         int percent
 ) {
@@ -16,8 +17,9 @@ public record OptionRoomBalanceVoteResponse(
     public static OptionRoomBalanceVoteResponse create(BalanceOption balanceOption,
                                                        List<RoomBalanceVote> optionVotes,
                                                        int contentVoteCount) {
-        List<String> members = optionVotes.stream()
-                .map(RoomBalanceVote::getMemberNickname)
+        List<MemberResponse> members = optionVotes.stream()
+                .map(RoomBalanceVote::getMember)
+                .map(MemberResponse::new)
                 .toList(); // todo member n + 1
 
         return new OptionRoomBalanceVoteResponse(

--- a/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/RoomMemberVoteMatchingResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/balance/roomvote/dto/RoomMemberVoteMatchingResponse.java
@@ -6,10 +6,11 @@ public record RoomMemberVoteMatchingResponse(
         int rank,
         long memberId,
         String nickname,
+        String imageUrl,
         long matchingPercent
 ) {
 
     public RoomMemberVoteMatchingResponse(int rank, Member member, long matchingPercent) {
-        this(rank, member.getId(), member.getNickname(), matchingPercent);
+        this(rank, member.getId(), member.getNickname(), member.getImageUrl(), matchingPercent);
     }
 }

--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
@@ -1,9 +1,22 @@
 package ddangkong.facade.room.dto;
 
+import ddangkong.domain.room.Room;
+import ddangkong.domain.room.member.Member;
 import jakarta.validation.constraints.NotBlank;
 
 public record RoomJoinRequest(
         @NotBlank
-        String nickname
+        String nickname,
+
+        @NotBlank
+        String imageUrl
 ) {
+
+    public Member toMasterMember(Room room) {
+        return Member.createMaster(nickname, imageUrl, room);
+    }
+
+    public Member toCommonMember(Room room) {
+        return Member.createCommon(nickname, imageUrl, room);
+    }
 }

--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
@@ -1,7 +1,5 @@
 package ddangkong.facade.room.dto;
 
-import ddangkong.domain.room.Room;
-import ddangkong.domain.room.member.Member;
 import jakarta.validation.constraints.NotBlank;
 
 public record RoomJoinRequest(
@@ -12,11 +10,4 @@ public record RoomJoinRequest(
         String imageUrl
 ) {
 
-    public Member toMasterMember(Room room) {
-        return Member.createMaster(nickname, imageUrl, room);
-    }
-
-    public Member toCommonMember(Room room) {
-        return Member.createCommon(nickname, imageUrl, room);
-    }
 }

--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
@@ -6,8 +6,14 @@ public record RoomJoinRequest(
         @NotBlank
         String nickname,
 
-        @NotBlank
         String imageUrl
 ) {
 
+    @Override
+    public String imageUrl() { // TODO : FE 작업 끝난 후 삭제 예정
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return "https://velog.velcdn.com/images/gwichanlee/post/dfdaead8-d98a-4d42-a975-2fb3edd7dde6/image.png";
+        }
+        return imageUrl;
+    }
 }

--- a/backend/src/main/java/ddangkong/facade/room/member/dto/MemberResponse.java
+++ b/backend/src/main/java/ddangkong/facade/room/member/dto/MemberResponse.java
@@ -5,9 +5,11 @@ import ddangkong.domain.room.member.Member;
 public record MemberResponse(
         Long memberId,
         String nickname,
+        String imageUrl,
         boolean isMaster
 ) {
+
     public MemberResponse(Member member) {
-        this(member.getId(), member.getNickname(), member.isMaster());
+        this(member.getId(), member.getNickname(), member.getImageUrl(), member.isMaster());
     }
 }

--- a/backend/src/main/java/ddangkong/service/room/member/MemberService.java
+++ b/backend/src/main/java/ddangkong/service/room/member/MemberService.java
@@ -23,12 +23,19 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member saveMasterMember(String nickname, Room room) {
-        if (existsMasterInRoom(room)) {
+    public Member saveMember(Member member) {
+        if (member.isMaster()) {
+            return saveMasterMember(member);
+        }
+        return saveCommonMember(member);
+    }
+
+    private Member saveMasterMember(Member member) {
+        if (existsMasterInRoom(member.getRoom())) {
             throw new AlreadyExistMasterException();
         }
-        validateMemberNotExists(room);
-        return memberRepository.save(Member.createMaster(nickname, "https://example.image", room));
+        validateMemberNotExists(member.getRoom());
+        return memberRepository.save(member);
     }
 
     private void validateMemberNotExists(Room room) {
@@ -38,14 +45,12 @@ public class MemberService {
         }
     }
 
-    @Transactional
-    public Member saveCommonMember(String nickname, Room room) {
-        if (!existsMasterInRoom(room)) {
+    private Member saveCommonMember(Member member) {
+        if (!existsMasterInRoom(member.getRoom())) {
             throw new NotExistMasterException();
         }
-        validateRoomAcceptMember(room);
-        // todo 중복 닉네임 체크
-        return memberRepository.save(Member.createCommon(nickname, "https://example.image", room)); // TODO 개선
+        validateRoomAcceptMember(member.getRoom());
+        return memberRepository.save(member);
     }
 
     private boolean existsMasterInRoom(Room room) {
@@ -98,11 +103,6 @@ public class MemberService {
     public void deleteMember(Room room) {
         RoomMembers members = findRoomMembers(room);
         memberRepository.deleteAllInBatch(members.getMembers());
-    }
-
-    @Transactional(readOnly = true)
-    public Member getMaster(Room room) {
-        return findRoomMembers(room).getMaster();
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/ddangkong/service/room/member/MemberService.java
+++ b/backend/src/main/java/ddangkong/service/room/member/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
             throw new AlreadyExistMasterException();
         }
         validateMemberNotExists(room);
-        return memberRepository.save(Member.createMaster(nickname, room));
+        return memberRepository.save(Member.createMaster(nickname, "https://example.image", room));
     }
 
     private void validateMemberNotExists(Room room) {
@@ -45,7 +45,7 @@ public class MemberService {
         }
         validateRoomAcceptMember(room);
         // todo 중복 닉네임 체크
-        return memberRepository.save(Member.createCommon(nickname, room));
+        return memberRepository.save(Member.createCommon(nickname, "https://example.image", room)); // TODO 개선
     }
 
     private boolean existsMasterInRoom(Room room) {

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -31,7 +31,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방을_생성할_수_있다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("방장");
+            RoomJoinRequest body = new RoomJoinRequest("방장", "https://example.image");
 
             // when & then
             RestAssured.given().log().all()
@@ -46,7 +46,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방을_생성한_사용자는_방장이다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("방장");
+            RoomJoinRequest body = new RoomJoinRequest("방장", "https://example.image");
 
             // when & then
             RoomJoinResponse actual = RestAssured.given().log().all()
@@ -426,7 +426,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방_생성시_멤버_식별_쿠키를_생성한다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("방장");
+            RoomJoinRequest body = new RoomJoinRequest("방장", "https://example.image");
 
             // when
             String cookie = RestAssured.given().log().all()
@@ -443,7 +443,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방_참여시_멤버_식별_쿠키를_생성한다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("참가자");
+            RoomJoinRequest body = new RoomJoinRequest("참가자", "https://example.image");
 
             // when
             String cookie = RestAssured.given().log().all()
@@ -460,7 +460,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 멤버_식별_쿠키를_통해_멤버_정보를_조회_할_수_있다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("참가자");
+            RoomJoinRequest body = new RoomJoinRequest("참가자", "https://example.image");
             String cookie = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
                     .body(body)
@@ -483,7 +483,7 @@ class RoomControllerTest extends BaseControllerTest {
         @Test
         void 방을_나가면_멤버_식별_쿠키를_삭제한다() {
             // given
-            RoomJoinRequest body = new RoomJoinRequest("참가자");
+            RoomJoinRequest body = new RoomJoinRequest("참가자", "https://example.image");
             String cookie = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
                     .body(body)

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -47,7 +47,7 @@ class RoomControllerTest extends BaseControllerTest {
             // given
             RoomJoinRequest body = new RoomJoinRequest("방장", "https://example.image");
 
-            // when & then
+            // when
             RoomJoinResponse actual = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
                     .body(body)
@@ -56,7 +56,12 @@ class RoomControllerTest extends BaseControllerTest {
                     .statusCode(201)
                     .extract().as(RoomJoinResponse.class);
 
-            assertThat(actual.member().isMaster()).isTrue();
+            // then
+            assertAll(
+                    () -> assertThat(actual.member().nickname()).isEqualTo(body.nickname()),
+                    () -> assertThat(actual.member().imageUrl()).isEqualTo(body.imageUrl()),
+                    () -> assertThat(actual.member().isMaster()).isTrue()
+            );
         }
     }
 
@@ -247,7 +252,9 @@ class RoomControllerTest extends BaseControllerTest {
 
             assertAll(
                     () -> assertThat(actual.roomId()).isEqualTo(room.getId()),
-                    () -> assertThat(actual.member().nickname()).isEqualTo(request.nickname())
+                    () -> assertThat(actual.member().nickname()).isEqualTo(request.nickname()),
+                    () -> assertThat(actual.member().imageUrl()).isEqualTo(request.imageUrl()),
+                    () -> assertThat(actual.member().isMaster()).isFalse()
             );
         }
     }
@@ -458,7 +465,10 @@ class RoomControllerTest extends BaseControllerTest {
                     .extract().as(RoomJoinResponse.class);
 
             // then
-            assertThat(body.nickname()).isEqualTo(roomJoinResponse.member().nickname());
+            assertAll(
+                    () -> assertThat(body.nickname()).isEqualTo(roomJoinResponse.member().nickname()),
+                    () -> assertThat(body.imageUrl()).isEqualTo(roomJoinResponse.member().imageUrl())
+            );
         }
 
         @Test

--- a/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/RoomControllerTest.java
@@ -18,7 +18,6 @@ import ddangkong.facade.room.dto.RoomStatusResponse;
 import ddangkong.facade.room.dto.RoundFinishedResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -229,45 +228,27 @@ class RoomControllerTest extends BaseControllerTest {
     class 방_참가 {
 
         @Test
-        void 방에_참가할_수_있다() {
+        void 방에_일반_멤버가_참가할_수_있다() {
             // given
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
 
-            String nickname = "참가자";
-            Map<String, Object> body = Map.of("nickname", nickname);
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .pathParam("uuid", room.getUuid())
-                    .body(body)
-                    .when().post("/api/balances/rooms/{uuid}/members")
-                    .then().log().all()
-                    .statusCode(201)
-                    .extract().as(RoomJoinResponse.class);
-        }
-
-        @Test
-        void 방에_참가한_멤버는_방장이_아니다() {
-            // given
-            Room room = roomFixture.createNotStartedRoom();
-            memberFixture.createMaster(room);
-
-            String nickname = "참가자";
-            Map<String, Object> body = Map.of("nickname", nickname);
+            RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
 
             // when & then
             RoomJoinResponse actual = RestAssured.given().log().all()
                     .contentType(ContentType.JSON)
                     .pathParam("uuid", room.getUuid())
-                    .body(body)
+                    .body(request)
                     .when().post("/api/balances/rooms/{uuid}/members")
                     .then().log().all()
                     .statusCode(201)
                     .extract().as(RoomJoinResponse.class);
 
-            assertThat(actual.member().isMaster()).isFalse();
+            assertAll(
+                    () -> assertThat(actual.roomId()).isEqualTo(room.getId()),
+                    () -> assertThat(actual.member().nickname()).isEqualTo(request.nickname())
+            );
         }
     }
 

--- a/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
@@ -15,6 +15,7 @@ import ddangkong.domain.room.balance.roomvote.RoomBalanceVote;
 import ddangkong.domain.room.member.Member;
 import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteRequest;
 import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResponse;
+import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResultResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMembersVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.VoteFinishedResponse;
 import ddangkong.support.annotation.FixedClock;
@@ -37,6 +38,50 @@ class RoomBalanceVoteControllerTest extends BaseControllerTest {
         balanceContent = balanceContentFixture.create();
         optionA = balanceOptionFixture.create(balanceContent);
         optionB = balanceOptionFixture.create(balanceContent);
+    }
+
+    @Nested
+    class 투표_결과_조회 {
+
+        @Test
+        void 투표_결과를_조회한다() {
+            // given
+            Room room = roomFixture.createProgressRoom(1);
+            memberFixture.createMaster(room);
+            Member common = memberFixture.createCommon(room);
+
+            LocalDateTime voteDeadline = LocalDateTime.parse("2024-07-18T20:00:08");
+            RoomContent content = roomContentFixture.create(room, balanceContent, 1, voteDeadline);
+
+            roomBalanceVoteFixture.create(common, optionA);
+
+            // when
+            RoomBalanceVoteResultResponse actual = RestAssured.given().log().all()
+                    .pathParam("roomId", room.getId())
+                    .pathParam("contentId", content.getId())
+                    .when().get("/api/balances/rooms/{roomId}/contents/{contentId}/vote-result")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract().as(RoomBalanceVoteResultResponse.class);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.group().firstOption().optionId()).isEqualTo(optionA.getId()),
+                    () -> assertThat(actual.group().firstOption().memberCount()).isEqualTo(1),
+                    () -> assertThat(actual.group().firstOption().members()).hasSize(1),
+                    () -> assertThat(actual.group().firstOption().percent()).isEqualTo(100),
+                    () -> assertThat(actual.group().secondOption().optionId()).isEqualTo(optionB.getId()),
+                    () -> assertThat(actual.group().secondOption().memberCount()).isZero(),
+                    () -> assertThat(actual.group().secondOption().members()).isEmpty(),
+                    () -> assertThat(actual.group().secondOption().percent()).isZero(),
+                    () -> assertThat(actual.group().giveUp().memberCount()).isEqualTo(1),
+                    () -> assertThat(actual.group().giveUp().members()).hasSize(1),
+                    () -> assertThat(actual.total().firstOption().optionId()).isEqualTo(optionA.getId()),
+                    () -> assertThat(actual.total().firstOption().name()).isEqualTo(optionA.getName()),
+                    () -> assertThat(actual.total().secondOption().optionId()).isEqualTo(optionB.getId()),
+                    () -> assertThat(actual.total().secondOption().name()).isEqualTo(optionB.getName())
+            );
+        }
     }
 
     @Nested

--- a/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
+++ b/backend/src/test/java/ddangkong/controller/room/balance/roomvote/RoomBalanceVoteControllerTest.java
@@ -210,10 +210,12 @@ class RoomBalanceVoteControllerTest extends BaseControllerTest {
                     () -> assertThat(actual.existMatching()).isTrue(),
                     () -> assertThat(actual.matchedMembers()).hasSize(2),
                     () -> assertThat(actual.matchedMembers().get(0).memberId()).isEqualTo(common1.getId()),
+                    () -> assertThat(actual.matchedMembers().get(0).imageUrl()).isNotNull(),
                     () -> assertThat(actual.matchedMembers().get(0).rank()).isEqualTo(1),
                     () -> assertThat(actual.matchedMembers().get(0).matchingPercent()).isEqualTo(100),
                     () -> assertThat(actual.matchedMembers().get(1).memberId()).isEqualTo(common2.getId()),
-                    () -> assertThat(actual.matchedMembers().get(1).matchingPercent()).isEqualTo(0),
+                    () -> assertThat(actual.matchedMembers().get(1).matchingPercent()).isZero(),
+                    () -> assertThat(actual.matchedMembers().get(1).imageUrl()).isNotNull(),
                     () -> assertThat(actual.matchedMembers().get(1).rank()).isEqualTo(2)
             );
         }

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -68,7 +68,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         @Test
         void 방을_생성한다() throws Exception {
             // given
-            MemberResponse memberResponse = new MemberResponse(1L, "땅콩", true);
+            MemberResponse memberResponse = new MemberResponse(1L, "땅콩", "https://example.image", true);
             RoomJoinRequest request = new RoomJoinRequest("땅콩", "https://example.image");
             RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c", memberResponse);
             when(roomFacade.createRoom(request)).thenReturn(response);
@@ -90,6 +90,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("roomUuid").type(STRING).description("생성된 방의 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
+                                    fieldWithPath("member.imageUrl").type(STRING).description("멤버 이미지 URL"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")
                             ),
                             responseCookies(
@@ -111,8 +112,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             Category category = Category.IF;
             RoomSettingResponse roomSetting = new RoomSettingResponse(5, 30, BalanceCategoryResponse.create(category));
             List<MemberResponse> members = List.of(
-                    new MemberResponse(1L, "땅콩", true),
-                    new MemberResponse(2L, "타콩", false)
+                    new MemberResponse(1L, "땅콩", "https://example.image", true),
+                    new MemberResponse(2L, "타콩", "https://example.image", false)
             );
             MasterResponse master = new MasterResponse(1L, "땅콩");
             RoomInfoResponse response = new RoomInfoResponse(false, roomSetting, members, master);
@@ -136,6 +137,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("members").type(ARRAY).description("방에 참여중 인원 목록"),
                                     fieldWithPath("members[].memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("members[].nickname").type(STRING).description("멤버 닉네임"),
+                                    fieldWithPath("members[].imageUrl").type(STRING).description("멤버 이미지 URL"),
                                     fieldWithPath("members[].isMaster").type(BOOLEAN).description("방장 여부"),
                                     fieldWithPath("master").type(OBJECT).description("방장 정보"),
                                     fieldWithPath("master.memberId").type(NUMBER).description("멤버 ID"),
@@ -186,7 +188,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             // given
             RoomJoinRequest request = new RoomJoinRequest("타콩", "https://example.image");
             RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
-                    new MemberResponse(2L, "타콩", false));
+                    new MemberResponse(2L, "타콩", "https://example.image", false));
             when(roomFacade.joinRoom(eq(request), anyString())).thenReturn(response);
             String content = objectMapper.writeValueAsString(request);
 
@@ -209,6 +211,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("roomUuid").type(STRING).description("참여한 방 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
+                                    fieldWithPath("member.imageUrl").type(STRING).description("멤버 이미지 URL"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")
                             ),
                             responseCookies(
@@ -256,7 +259,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         void 사용자_정보를_조회한다() throws Exception {
             // given
             RoomMemberResponse response = new RoomMemberResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
-                    new MemberResponse(2L, "타콩", false));
+                    new MemberResponse(2L, "타콩", "https://example.image", false));
             when(roomFacade.getRoomMemberInfo(anyLong())).thenReturn(response);
 
             //when & then
@@ -275,6 +278,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     fieldWithPath("roomUuid").type(STRING).description("참여한 방 UUID"),
                                     fieldWithPath("member.memberId").type(NUMBER).description("멤버 ID"),
                                     fieldWithPath("member.nickname").type(STRING).description("멤버 닉네임"),
+                                    fieldWithPath("member.imageUrl").type(STRING).description("멤버 이미지 URL"),
                                     fieldWithPath("member.isMaster").type(BOOLEAN).description("방장 여부")
                             )
                     ));

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -3,6 +3,7 @@ package ddangkong.documentation.room;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
@@ -68,10 +69,9 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         void 방을_생성한다() throws Exception {
             // given
             MemberResponse memberResponse = new MemberResponse(1L, "땅콩", true);
-            RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c", memberResponse);
-            when(roomFacade.createRoom(anyString())).thenReturn(response);
-
             RoomJoinRequest request = new RoomJoinRequest("땅콩", "https://example.image");
+            RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c", memberResponse);
+            when(roomFacade.createRoom(request)).thenReturn(response);
             String content = objectMapper.writeValueAsString(request);
 
             // when & then
@@ -184,11 +184,10 @@ class RoomDocumentationTest extends BaseDocumentationTest {
         @Test
         void 방에_참여한다() throws Exception {
             // given
+            RoomJoinRequest request = new RoomJoinRequest("타콩", "https://example.image");
             RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c",
                     new MemberResponse(2L, "타콩", false));
-            when(roomFacade.joinRoom(anyString(), anyString())).thenReturn(response);
-
-            RoomJoinRequest request = new RoomJoinRequest("타콩", "https://example.image");
+            when(roomFacade.joinRoom(eq(request), anyString())).thenReturn(response);
             String content = objectMapper.writeValueAsString(request);
 
             //when & then

--- a/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/RoomDocumentationTest.java
@@ -71,7 +71,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
             RoomJoinResponse response = new RoomJoinResponse(1L, "488fd79f92a34131bf2a628bd58c5d2c", memberResponse);
             when(roomFacade.createRoom(anyString())).thenReturn(response);
 
-            RoomJoinRequest request = new RoomJoinRequest("땅콩");
+            RoomJoinRequest request = new RoomJoinRequest("땅콩", "https://example.image");
             String content = objectMapper.writeValueAsString(request);
 
             // when & then
@@ -82,7 +82,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                     .andExpect(status().isCreated())
                     .andDo(document("room/create",
                             requestFields(
-                                    fieldWithPath("nickname").description("닉네임")
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("imageUrl").type(STRING).description("이미지 URL")
                             ),
                             responseFields(
                                     fieldWithPath("roomId").type(NUMBER).description("생성된 방 ID"),
@@ -187,7 +188,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                     new MemberResponse(2L, "타콩", false));
             when(roomFacade.joinRoom(anyString(), anyString())).thenReturn(response);
 
-            RoomJoinRequest request = new RoomJoinRequest("타콩");
+            RoomJoinRequest request = new RoomJoinRequest("타콩", "https://example.image");
             String content = objectMapper.writeValueAsString(request);
 
             //when & then
@@ -201,7 +202,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                                     parameterWithName("uuid").description("참여하는 방 UUID")
                             ),
                             requestFields(
-                                    fieldWithPath("nickname").description("닉네임")
+                                    fieldWithPath("nickname").description("닉네임"),
+                                    fieldWithPath("imageUrl").type(STRING).description("이미지 URL")
                             ),
                             responseFields(
                                     fieldWithPath("roomId").type(NUMBER).description("참여한 방 ID"),
@@ -266,7 +268,8 @@ class RoomDocumentationTest extends BaseDocumentationTest {
                     .andExpect(status().isOk())
                     .andDo(document("room/member",
                             requestCookies(
-                                    cookieWithName("test_cookie").description("사용자 인증에 필요한 쿠키(쿠키의 키 값은 UUID로 예측할 수 없는 값이 들어감)")
+                                    cookieWithName("test_cookie").description(
+                                            "사용자 인증에 필요한 쿠키(쿠키의 키 값은 UUID로 예측할 수 없는 값이 들어감)")
                             ),
                             responseFields(
                                     fieldWithPath("roomId").type(NUMBER).description("참여한 방 ID"),
@@ -350,6 +353,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
 
     @Nested
     class 게임_중단 {
+
         private static final String ENDPOINT = "/api/balances/rooms/{roomId}/stop";
 
         @Test
@@ -400,6 +404,7 @@ class RoomDocumentationTest extends BaseDocumentationTest {
 
     @Nested
     class 방_게임_참여_가능_여부 {
+
         private static final String ENDPOINT = "/api/balances/rooms/{uuid}/status";
 
         @Test

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
@@ -31,6 +31,7 @@ import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResultResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMemberVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMembersVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.VoteFinishedResponse;
+import ddangkong.facade.room.member.dto.MemberResponse;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -56,12 +57,15 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
             Long contentId = 1L;
 
             OptionRoomBalanceVoteResponse firstGroupResponse = new OptionRoomBalanceVoteResponse(1L, "민초",
-                    List.of("mohamedeu al katan", "deundeun", "rupi"), 3, 75);
+                    List.of(new MemberResponse(2L, "mohamedeu al katan", "https://image.kr", true),
+                            new MemberResponse(3L, "deundeun", "https://image.kr", false),
+                            new MemberResponse(4L, "rupi", "https://image.kr", false)), 3, 75);
             OptionRoomBalanceVoteResponse secondGroupResponse = new OptionRoomBalanceVoteResponse(2L, "반민초",
-                    List.of("rapper lee"), 1, 25);
+                    List.of(new MemberResponse(5L, "rapper lee", "https://image.kr", false)), 1, 25);
             OptionTotalBalanceVoteResponse firstTotalResponse = new OptionTotalBalanceVoteResponse(1L, "민초", 50);
             OptionTotalBalanceVoteResponse secondTotalResponse = new OptionTotalBalanceVoteResponse(2L, "반민초", 50);
-            GiveUpVoteMemberResponse giveUpVoteMemberResponse = new GiveUpVoteMemberResponse(List.of("jason"), 1);
+            GiveUpVoteMemberResponse giveUpVoteMemberResponse = new GiveUpVoteMemberResponse(
+                    List.of(new MemberResponse(6L, "jason", "https://image.kr", false)), 1);
 
             RoomBalanceVoteResultResponse response = new RoomBalanceVoteResultResponse(
                     new ContentRoomBalanceVoteResponse(firstGroupResponse, secondGroupResponse,
@@ -83,16 +87,30 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             fieldWithPath("group.firstOption").type(OBJECT).description("그룹 내 첫 번째 선택지 결과"),
                                             fieldWithPath("group.firstOption.optionId").type(NUMBER).description("선택지 ID"),
                                             fieldWithPath("group.firstOption.name").type(STRING).description("선택지 이름"),
-                                            fieldWithPath("group.firstOption.members").type(ARRAY)
-                                                    .description("선택지를 선택한 멤버들의 닉네임"),
+                                            fieldWithPath("group.firstOption.members").type(ARRAY).description("선택지를 선택한 멤버들"),
+                                            fieldWithPath("group.firstOption.members[].memberId").type(NUMBER)
+                                                    .description("멤버 ID"),
+                                            fieldWithPath("group.firstOption.members[].nickname").type(STRING)
+                                                    .description("멤버 닉네임"),
+                                            fieldWithPath("group.firstOption.members[].imageUrl").type(STRING)
+                                                    .description("멤버 이미지 URL"),
+                                            fieldWithPath("group.firstOption.members[].isMaster").type(BOOLEAN)
+                                                    .description("방장 여부"),
                                             fieldWithPath("group.firstOption.memberCount").type(NUMBER)
                                                     .description("선택지를 선택한 사람 수"),
                                             fieldWithPath("group.firstOption.percent").type(NUMBER).description("선택지를 선택한 퍼센트"),
                                             fieldWithPath("group.secondOption").type(OBJECT).description("그룹 내 두 번째 선택지 결과"),
                                             fieldWithPath("group.secondOption.optionId").type(NUMBER).description("선택지 ID"),
                                             fieldWithPath("group.secondOption.name").type(STRING).description("선택지 이름"),
-                                            fieldWithPath("group.secondOption.members").type(ARRAY)
-                                                    .description("선택지를 선택한 멤버들의 닉네임"),
+                                            fieldWithPath("group.secondOption.members").type(ARRAY).description("선택지를 선택한 멤버들"),
+                                            fieldWithPath("group.secondOption.members[].memberId").type(NUMBER)
+                                                    .description("멤버 ID"),
+                                            fieldWithPath("group.secondOption.members[].nickname").type(STRING)
+                                                    .description("멤버 닉네임"),
+                                            fieldWithPath("group.secondOption.members[].imageUrl").type(STRING)
+                                                    .description("멤버 이미지 URL"),
+                                            fieldWithPath("group.secondOption.members[].isMaster").type(BOOLEAN)
+                                                    .description("방장 여부"),
                                             fieldWithPath("group.secondOption.memberCount").type(NUMBER)
                                                     .description("선택지를 선택한 사람 수"),
                                             fieldWithPath("group.secondOption.percent").type(NUMBER)
@@ -100,8 +118,15 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             fieldWithPath("group.giveUp").type(OBJECT).description("기권한 멤버 정보"),
                                             fieldWithPath("group.giveUp.members").type(ARRAY)
                                                     .description("기권한 멤버들의 닉네임"),
-                                            fieldWithPath("group.giveUp.memberCount").type(NUMBER)
-                                                    .description("기권한 멤버 수"),
+                                            fieldWithPath("group.giveUp.members[].memberId").type(NUMBER)
+                                                    .description("멤버 ID"),
+                                            fieldWithPath("group.giveUp.members[].nickname").type(STRING)
+                                                    .description("멤버 닉네임"),
+                                            fieldWithPath("group.giveUp.members[].imageUrl").type(STRING)
+                                                    .description("멤버 이미지 URL"),
+                                            fieldWithPath("group.giveUp.members[].isMaster").type(BOOLEAN)
+                                                    .description("방장 여부"),
+                                            fieldWithPath("group.giveUp.memberCount").type(NUMBER).description("기권한 멤버 수"),
                                             fieldWithPath("total").type(OBJECT).description("전체 유저 결과"),
                                             fieldWithPath("total.firstOption").type(OBJECT).description("전체 유저 첫 번째 선택지 결과"),
                                             fieldWithPath("total.firstOption.optionId").type(NUMBER).description("선택지 ID"),

--- a/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
+++ b/backend/src/test/java/ddangkong/documentation/room/balance/roomvote/RoomBalanceVoteDocumentationTest.java
@@ -31,7 +31,6 @@ import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResultResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMemberVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMembersVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.VoteFinishedResponse;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -196,11 +195,11 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
         void 종료된_방에서_특정_멤버에_대한_다른_멤버들의_투표_매칭도를_조회한다() throws Exception {
             // given
             boolean existMatching = true;
-            List<RoomMemberVoteMatchingResponse> roomMemberVoteMatchingResponse = new ArrayList<>();
-            roomMemberVoteMatchingResponse.add(new RoomMemberVoteMatchingResponse(1, 2, "프콩", 100));
-            roomMemberVoteMatchingResponse.add(new RoomMemberVoteMatchingResponse(1, 3, "타콩", 100));
-            roomMemberVoteMatchingResponse.add(new RoomMemberVoteMatchingResponse(3, 4, "타콩", 30));
-
+            List<RoomMemberVoteMatchingResponse> roomMemberVoteMatchingResponse = List.of(
+                    new RoomMemberVoteMatchingResponse(1, 2, "프콩", "https://image.kr", 100),
+                    new RoomMemberVoteMatchingResponse(1, 3, "타콩", "https://image.kr", 100),
+                    new RoomMemberVoteMatchingResponse(3, 4, "타콩", "https://image.kr", 30)
+            );
             RoomMembersVoteMatchingResponse response = new RoomMembersVoteMatchingResponse(
                     roomMemberVoteMatchingResponse,
                     existMatching);
@@ -219,6 +218,7 @@ public class RoomBalanceVoteDocumentationTest extends BaseDocumentationTest {
                                             fieldWithPath("matchedMembers[].rank").type(NUMBER).description("매칭 순위"),
                                             fieldWithPath("matchedMembers[].memberId").type(NUMBER).description("멤버 ID"),
                                             fieldWithPath("matchedMembers[].nickname").type(STRING).description("닉네임"),
+                                            fieldWithPath("matchedMembers[].imageUrl").type(STRING).description("이미지 URL"),
                                             fieldWithPath("matchedMembers[].matchingPercent").type(NUMBER)
                                                     .description("요청한 멤버와의 매칭도(%)"),
                                             fieldWithPath("existMatching").type(BOOLEAN).description("매칭 맴버 여부")

--- a/backend/src/test/java/ddangkong/domain/room/balance/roomvote/RoomBalanceVoteRepositoryTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/balance/roomvote/RoomBalanceVoteRepositoryTest.java
@@ -25,7 +25,7 @@ class RoomBalanceVoteRepositoryTest extends BaseRepositoryTest {
         void 같은_멤버가_같은_옵션에_투표하면_예외가_발생한다() {
             // given
             Room room = save(Room.createNewRoom());
-            Member master = save(Member.createMaster("member", room));
+            Member master = save(Member.createMaster("member", "https://example.image", room));
             BalanceContent content = save(new BalanceContent(Category.IF, "A vs B"));
             BalanceOption optionA = save(new BalanceOption("A", content));
 

--- a/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/member/MemberTest.java
@@ -1,10 +1,12 @@
 package ddangkong.domain.room.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ddangkong.domain.room.Room;
+import ddangkong.exception.room.InvalidImageUrlException;
 import ddangkong.exception.room.member.AlreadyCommonException;
 import ddangkong.exception.room.member.AlreadyMasterException;
 import ddangkong.exception.room.member.InvalidNicknameException;
@@ -12,6 +14,7 @@ import ddangkong.support.fixture.EntityFixtureUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class MemberTest {
@@ -24,7 +27,7 @@ class MemberTest {
         @Test
         void 일반_유저를_마스터로_변경할_수_있다() {
             // given
-            Member common = Member.createCommon("prin", ROOM);
+            Member common = Member.createCommon("prin", "https://example.image", ROOM);
 
             // when
             common.promoteToMaster();
@@ -36,11 +39,11 @@ class MemberTest {
         @Test
         void 마스터_유저인_경우_예외를_발생한다() {
             // given
-            Member master = Member.createMaster("prin", ROOM);
+            Member master = Member.createMaster("prin", "https://example.image", ROOM);
             EntityFixtureUtils.setId(master, 3L);
 
             // when & then
-            assertThatThrownBy(() -> master.promoteToMaster())
+            assertThatThrownBy(master::promoteToMaster)
                     .isExactlyInstanceOf(AlreadyMasterException.class)
                     .hasMessage("해당 멤버는 이미 방장입니다. memberId : 3");
         }
@@ -52,7 +55,7 @@ class MemberTest {
         @Test
         void 마스터_유저를_일반_유저로_변경할_수_있다() {
             // given
-            Member master = Member.createMaster("prin", ROOM);
+            Member master = Member.createMaster("prin", "https://example.image", ROOM);
 
             // when
             master.demoteToCommon();
@@ -64,7 +67,7 @@ class MemberTest {
         @Test
         void 일반_유저인_경우_예외를_발생한다() {
             // given
-            Member common = Member.createCommon("prin", ROOM);
+            Member common = Member.createCommon("prin", "https://example.image", ROOM);
             EntityFixtureUtils.setId(common, 3L);
 
             // when & then
@@ -79,7 +82,7 @@ class MemberTest {
 
         @Test
         void 일반_유저인지_확인_할_수_있다() {
-            Member common = Member.createCommon("prin", ROOM);
+            Member common = Member.createCommon("prin", "https://example.image", ROOM);
 
             boolean actual = common.isCommon();
 
@@ -88,7 +91,7 @@ class MemberTest {
 
         @Test
         void 마스터_유저는_일반_유저가_아니다() {
-            Member master = Member.createMaster("prin", ROOM);
+            Member master = Member.createMaster("prin", "https://example.image", ROOM);
 
             boolean actual = master.isCommon();
 
@@ -103,15 +106,35 @@ class MemberTest {
         @ValueSource(strings = {"01", "012345678912"})
         void 닉네임_길이가_유효한_경우_예외가_발생하지_않는다(String name) {
             // when & then
-            assertThatNoException().isThrownBy(() -> Member.createMaster(name, ROOM));
+            assertThatNoException().isThrownBy(() -> Member.createMaster(name, "https://example.image", ROOM));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {" ", "", "0123456789123"})
         void 닉네임_길이가_유효하지_않는_경우_예외를_발생시킨다(String name) {
             // when & then
-            assertThatThrownBy(() -> Member.createMaster(name, ROOM))
+            assertThatThrownBy(() -> Member.createMaster(name, "https://example.image", ROOM))
                     .isExactlyInstanceOf(InvalidNicknameException.class);
+        }
+    }
+
+    @Nested
+    class 이미지_URL_검증 {
+
+        @Test
+        void 이미지_URL이_유효한_경우_예외가_발생하지_않는다() {
+            // when & then
+            assertThatCode(() -> Member.createMaster("prin", "https://example.image", ROOM))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"is-not-image", "http://example.image"})
+        void 이미지_URL이_유효하지_않는_경우_예외를_발생시킨다(String imageUrl) {
+            // when & then
+            assertThatThrownBy(() -> Member.createMaster("prin", imageUrl, ROOM))
+                    .isExactlyInstanceOf(InvalidImageUrlException.class);
         }
     }
 }

--- a/backend/src/test/java/ddangkong/domain/room/member/RoomMembersTest.java
+++ b/backend/src/test/java/ddangkong/domain/room/member/RoomMembersTest.java
@@ -29,8 +29,8 @@ class RoomMembersTest {
         @Test
         void 방_멤버들_객체를_생성한다() {
             // given
-            Member master = Member.createMaster("master", room);
-            Member member1 = Member.createCommon("common", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
+            Member member1 = Member.createCommon("common", "https://example.image", room);
             List<Member> members = List.of(master, member1);
 
             // when
@@ -43,8 +43,8 @@ class RoomMembersTest {
         @Test
         void 방장이_여러명인_경우_예외를_발생한다() {
             // given
-            Member master1 = Member.createMaster("master1", room);
-            Member master2 = Member.createMaster("master2", room);
+            Member master1 = Member.createMaster("master1", "https://example.image", room);
+            Member master2 = Member.createMaster("master2", "https://example.image", room);
             List<Member> members = List.of(master1, master2);
 
             // when & then
@@ -56,8 +56,8 @@ class RoomMembersTest {
         @Test
         void 방장이_없는_경우_예외가_발생한다() {
             // given
-            Member member1 = Member.createCommon("common1", room);
-            Member member2 = Member.createCommon("common2", room);
+            Member member1 = Member.createCommon("common1", "https://example.image", room);
+            Member member2 = Member.createCommon("common2", "https://example.image", room);
             List<Member> members = List.of(member1, member2);
 
             // when & then
@@ -80,8 +80,8 @@ class RoomMembersTest {
         @Test
         void 방장을_조회한다() {
             // given
-            Member master = Member.createMaster("master", room);
-            Member member1 = Member.createCommon("common1", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
+            Member member1 = Member.createCommon("common1", "https://example.image", room);
             List<Member> members = List.of(master, member1);
             RoomMembers roomMembers = new RoomMembers(members);
 
@@ -106,11 +106,11 @@ class RoomMembersTest {
         @Test
         void 임의의_일반_멤버를_조회할_수_있다() {
             // given
-            Member master = Member.createMaster("master", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
             EntityFixtureUtils.setId(master, 1L);
-            Member member1 = Member.createCommon("common1", room);
+            Member member1 = Member.createCommon("common1", "https://example.image", room);
             EntityFixtureUtils.setId(member1, 2L);
-            Member member2 = Member.createCommon("common2", room);
+            Member member2 = Member.createCommon("common2", "https://example.image", room);
             EntityFixtureUtils.setId(member2, 3L);
             List<Member> members = List.of(master, member1, member2);
             RoomMembers roomMembers = new RoomMembers(members);
@@ -125,13 +125,13 @@ class RoomMembersTest {
         @Test
         void 일반_멤버가_없다면_예외를_발생시킨다() {
             // given
-            Member master = Member.createMaster("master", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
             EntityFixtureUtils.setId(master, 1L);
             List<Member> members = List.of(master);
             RoomMembers roomMembers = new RoomMembers(members);
 
             // when & then
-            assertThatThrownBy(() -> roomMembers.getAnyCommonMember())
+            assertThatThrownBy(roomMembers::getAnyCommonMember)
                     .isExactlyInstanceOf(NotExistCommonMemberException.class);
         }
     }
@@ -149,11 +149,11 @@ class RoomMembersTest {
         @Test
         void 특정_멤버를_조회한다() {
             // given
-            Member master = Member.createMaster("master", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
             EntityFixtureUtils.setId(master, 1L);
-            Member member1 = Member.createCommon("common1", room);
+            Member member1 = Member.createCommon("common1", "https://example.image", room);
             EntityFixtureUtils.setId(member1, 2L);
-            Member member2 = Member.createCommon("common2", room);
+            Member member2 = Member.createCommon("common2", "https://example.image", room);
             EntityFixtureUtils.setId(member2, 3L);
             List<Member> members = List.of(master, member1, member2);
             RoomMembers roomMembers = new RoomMembers(members);
@@ -168,9 +168,9 @@ class RoomMembersTest {
         @Test
         void 존재하지_않는_멤버를_조회하면_예외가_발생한다() {
             // given
-            Member master = Member.createMaster("master", room);
+            Member master = Member.createMaster("master", "https://example.image", room);
             EntityFixtureUtils.setId(master, 1L);
-            Member member1 = Member.createCommon("common1", room);
+            Member member1 = Member.createCommon("common1", "https://example.image", room);
             EntityFixtureUtils.setId(member1, 2L);
             List<Member> members = List.of(master, member1);
             RoomMembers roomMembers = new RoomMembers(members);

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -48,14 +48,16 @@ class RoomFacadeTest extends BaseServiceTest {
         void 방_생성_시_방장_멤버를_생성하고_방을_생성한다() {
             // given
             RoomJoinRequest request = new RoomJoinRequest("방장", "https://example.image");
-            MemberResponse expectedMemberResponse = new MemberResponse(1L, "방장", true);
+            MemberResponse expectedMemberResponse = new MemberResponse(1L, "방장", "https://example.image", true);
 
             // when
             RoomJoinResponse actual = roomFacade.createRoom(request);
 
             // then
-            assertThat(actual.roomId()).isEqualTo(1L);
-            assertThat(actual.member()).isEqualTo(expectedMemberResponse);
+            assertAll(
+                    () -> assertThat(actual.roomId()).isEqualTo(1L),
+                    () -> assertThat(actual.member()).isEqualTo(expectedMemberResponse)
+            );
         }
     }
 
@@ -69,7 +71,7 @@ class RoomFacadeTest extends BaseServiceTest {
             memberFixture.createMaster(room);
 
             RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
-            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", false);
+            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", "https://example.image", false);
 
             // when
             RoomJoinResponse actual = roomFacade.joinRoom(request, room.getUuid());
@@ -130,7 +132,7 @@ class RoomFacadeTest extends BaseServiceTest {
             memberFixture.createMaster(room);
 
             RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
-            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", false);
+            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", "https://example.image", false);
             roomFacade.joinRoom(request, room.getUuid());
 
             // when
@@ -637,7 +639,7 @@ class RoomFacadeTest extends BaseServiceTest {
         @Test
         void 변경이_특정_시각_이후에_일어난_방은_지우지_않는다() {
             // given
-            LocalDateTime beforeModifiedAt = LocalDateTime.now();
+            LocalDateTime beforeModifiedAt = LocalDateTime.now().minusSeconds(1);
             roomFixture.createNotStartedRoom();
             roomFixture.createNotStartedRoom();
             long expectedCount = 2;

--- a/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/RoomFacadeTest.java
@@ -21,6 +21,7 @@ import ddangkong.exception.room.member.InvalidMemberIdException;
 import ddangkong.facade.BaseServiceTest;
 import ddangkong.facade.room.dto.InitialRoomResponse;
 import ddangkong.facade.room.dto.RoomInfoResponse;
+import ddangkong.facade.room.dto.RoomJoinRequest;
 import ddangkong.facade.room.dto.RoomJoinResponse;
 import ddangkong.facade.room.dto.RoomMemberResponse;
 import ddangkong.facade.room.dto.RoomSettingRequest;
@@ -46,11 +47,11 @@ class RoomFacadeTest extends BaseServiceTest {
         @Test
         void 방_생성_시_방장_멤버를_생성하고_방을_생성한다() {
             // given
-            String nickname = "방장";
-            MemberResponse expectedMemberResponse = new MemberResponse(1L, nickname, true);
+            RoomJoinRequest request = new RoomJoinRequest("방장", "https://example.image");
+            MemberResponse expectedMemberResponse = new MemberResponse(1L, "방장", true);
 
             // when
-            RoomJoinResponse actual = roomFacade.createRoom(nickname);
+            RoomJoinResponse actual = roomFacade.createRoom(request);
 
             // then
             assertThat(actual.roomId()).isEqualTo(1L);
@@ -67,11 +68,11 @@ class RoomFacadeTest extends BaseServiceTest {
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
 
-            String nickname = "참가자";
-            MemberResponse expectedMemberResponse = new MemberResponse(2L, nickname, false);
+            RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
+            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", false);
 
             // when
-            RoomJoinResponse actual = roomFacade.joinRoom(nickname, room.getUuid());
+            RoomJoinResponse actual = roomFacade.joinRoom(request, room.getUuid());
 
             // then
             assertAll(
@@ -84,11 +85,11 @@ class RoomFacadeTest extends BaseServiceTest {
         @Test
         void 존재하지_않는_방에_참여시_예외를_던진다() {
             // given
-            String nickname = "참가자";
             String nonExistUuid = "nonExistUuid";
+            RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
 
             // when & then
-            assertThatThrownBy(() -> roomFacade.joinRoom(nickname, nonExistUuid))
+            assertThatThrownBy(() -> roomFacade.joinRoom(request, nonExistUuid))
                     .isExactlyInstanceOf(NotFoundRoomException.class);
         }
 
@@ -98,10 +99,11 @@ class RoomFacadeTest extends BaseServiceTest {
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
             memberFixture.createCommons(room, 10);
+            RoomJoinRequest request = new RoomJoinRequest("member12", "https://example.image");
 
             // when
-            Thread t1 = new Thread(() -> roomFacade.joinRoom("member12-1", room.getUuid()));
-            Thread t2 = new Thread(() -> roomFacade.joinRoom("member12-2", room.getUuid()));
+            Thread t1 = new Thread(() -> roomFacade.joinRoom(request, room.getUuid()));
+            Thread t2 = new Thread(() -> roomFacade.joinRoom(request, room.getUuid()));
             t1.start();
             t2.start();
 
@@ -127,9 +129,9 @@ class RoomFacadeTest extends BaseServiceTest {
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
 
-            String nickname = "참가자";
-            MemberResponse expectedMemberResponse = new MemberResponse(2L, nickname, false);
-            roomFacade.joinRoom(nickname, room.getUuid());
+            RoomJoinRequest request = new RoomJoinRequest("참가자", "https://example.image");
+            MemberResponse expectedMemberResponse = new MemberResponse(2L, "참가자", false);
+            roomFacade.joinRoom(request, room.getUuid());
 
             // when
             RoomMemberResponse actual = roomFacade.getRoomMemberInfo(2L);

--- a/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
+++ b/backend/src/test/java/ddangkong/facade/room/balance/roomvote/RoomBalanceVoteFacadeTest.java
@@ -24,6 +24,7 @@ import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomBalanceVoteResultResponse;
 import ddangkong.facade.room.balance.roomvote.dto.RoomMembersVoteMatchingResponse;
 import ddangkong.facade.room.balance.roomvote.dto.VoteFinishedResponse;
+import ddangkong.facade.room.member.dto.MemberResponse;
 import ddangkong.support.annotation.FixedClock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -148,10 +149,11 @@ class RoomBalanceVoteFacadeTest extends BaseServiceTest {
             RoomBalanceVoteResultResponse expected = new RoomBalanceVoteResultResponse(
                     new ContentRoomBalanceVoteResponse(
                             new OptionRoomBalanceVoteResponse(option1.getId(), option1.getName(),
-                                    List.of(member1.getNickname(), member2.getNickname(), member3.getNickname()), 3,
-                                    75), new OptionRoomBalanceVoteResponse(option2.getId(), option2.getName(),
-                            List.of(member4.getNickname()), 1, 25),
-                            new GiveUpVoteMemberResponse(List.of(giveUpMember.getNickname()), 1)),
+                                    List.of(new MemberResponse(member1), new MemberResponse(member2),
+                                            new MemberResponse(member3)), 3, 75),
+                            new OptionRoomBalanceVoteResponse(option2.getId(), option2.getName(),
+                                    List.of(new MemberResponse(member4)), 1, 25),
+                            new GiveUpVoteMemberResponse(List.of(new MemberResponse(giveUpMember)), 1)),
                     new ContentTotalBalanceVoteResponse(
                             new OptionTotalBalanceVoteResponse(option1.getId(), option1.getName(), 0),
                             new OptionTotalBalanceVoteResponse(option2.getId(), option2.getName(), 0)));

--- a/backend/src/test/java/ddangkong/service/room/member/MemberServiceTest.java
+++ b/backend/src/test/java/ddangkong/service/room/member/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package ddangkong.service.room.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,16 +36,10 @@ class MemberServiceTest extends BaseServiceTest {
         void 방장을_생성한다() {
             // given
             Room room = roomFixture.createNotStartedRoom();
-            String masterNickname = "master";
+            Member master = Member.createMaster("master", "https://example.image", room);
 
-            // when
-            Member master = memberFixture.createMaster(masterNickname, room);
-
-            // then
-            assertAll(
-                    () -> assertThat(master.getNickname()).isEqualTo(masterNickname),
-                    () -> assertThat(master.isMaster()).isTrue()
-            );
+            // when & then
+            assertThatCode(() -> memberService.saveMember(master)).doesNotThrowAnyException();
         }
 
         @Test
@@ -52,9 +47,10 @@ class MemberServiceTest extends BaseServiceTest {
             // given
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
+            Member anotherMaster = Member.createMaster("anoMaster", "https://example.image", room);
 
             // when & then
-            assertThatThrownBy(() -> memberService.saveMasterMember("anotherMaster", room))
+            assertThatThrownBy(() -> memberService.saveMember(anotherMaster))
                     .isExactlyInstanceOf(AlreadyExistMasterException.class);
         }
 
@@ -63,9 +59,10 @@ class MemberServiceTest extends BaseServiceTest {
             // given
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createCommon(room);
+            Member master = Member.createMaster("master", "https://example.image", room);
 
             // when & then
-            assertThatThrownBy(() -> memberService.saveMasterMember("master", room))
+            assertThatThrownBy(() -> memberService.saveMember(master))
                     .isExactlyInstanceOf(InvalidMasterCreationException.class)
                     .hasMessage("방에 멤버가 존재하면 방장을 생성할 수 없습니다. 현재 멤버 수: 1");
         }
@@ -82,11 +79,13 @@ class MemberServiceTest extends BaseServiceTest {
 
             // when
             String commonMemberNickname = "commonMember";
-            Member eden = memberService.saveCommonMember(commonMemberNickname, room);
+            String imageUrl = "https://example.image";
+            Member eden = memberService.saveMember(Member.createCommon(commonMemberNickname, imageUrl, room));
 
             // then
             assertAll(
                     () -> assertThat(eden.getNickname()).isEqualTo(commonMemberNickname),
+                    () -> assertThat(eden.getImageUrl()).isEqualTo(imageUrl),
                     () -> assertThat(eden.isMaster()).isFalse()
             );
         }
@@ -96,9 +95,10 @@ class MemberServiceTest extends BaseServiceTest {
             // given
             Room progressRoom = roomFixture.createProgressRoom(1);
             memberFixture.createMaster(progressRoom);
+            Member member = Member.createCommon("newMember", "https://example.image", progressRoom);
 
             // when & then
-            assertThatThrownBy(() -> memberService.saveCommonMember("newMember", progressRoom))
+            assertThatThrownBy(() -> memberService.saveMember(member))
                     .isExactlyInstanceOf(NotReadyRoomException.class);
         }
 
@@ -106,9 +106,10 @@ class MemberServiceTest extends BaseServiceTest {
         void 방장이_존재하지_않는_방에_일반_멤버를_생성하면_예외가_발생한다() {
             // given
             Room room = roomFixture.createNotStartedRoom();
+            Member member = Member.createCommon("newMember", "https://example.image", room);
 
             // when & then
-            assertThatThrownBy(() -> memberService.saveCommonMember("newMember", room))
+            assertThatThrownBy(() -> memberService.saveMember(member))
                     .isExactlyInstanceOf(NotExistMasterException.class);
         }
 
@@ -120,9 +121,10 @@ class MemberServiceTest extends BaseServiceTest {
             Room room = roomFixture.createNotStartedRoom();
             memberFixture.createMaster(room);
             memberFixture.createCommons(room, maxMemberCount - 1);
+            Member member = Member.createCommon("newMember", "https://example.image", room);
 
             // when & then
-            assertThatThrownBy(() -> memberService.saveCommonMember("newMember", room))
+            assertThatThrownBy(() -> memberService.saveMember(member))
                     .isExactlyInstanceOf(ExceedMaxMemberCountException.class)
                     .hasMessage("방의 최대 인원을 초과했습니다. 현재 멤버 수: 12");
         }

--- a/backend/src/test/java/ddangkong/support/fixture/domain/MemberFixture.java
+++ b/backend/src/test/java/ddangkong/support/fixture/domain/MemberFixture.java
@@ -10,6 +10,7 @@ public class MemberFixture {
 
     private static final String COMMON_NICKNAME = "common";
     private static final String MASTER_NICKNAME = "master";
+    private static final String DEFAULT_IMAGE_URL = "https://example.image";
 
     private final MemberRepository memberRepository;
 
@@ -18,7 +19,7 @@ public class MemberFixture {
     }
 
     private Member createCommon(String nickname, Room room) {
-        return memberRepository.save(Member.createCommon(nickname, room));
+        return memberRepository.save(Member.createCommon(nickname, DEFAULT_IMAGE_URL, room));
     }
 
     public Member createCommon(int order, Room room) {
@@ -36,7 +37,7 @@ public class MemberFixture {
     }
 
     public Member createMaster(String nickname, Room room) {
-        return memberRepository.save(Member.createMaster(nickname, room));
+        return memberRepository.save(Member.createMaster(nickname, DEFAULT_IMAGE_URL, room));
     }
 
     public Member createMaster(Room room) {


### PR DESCRIPTION
## Issue Number
closed #484 

## As-Is
<!-- 문제 상황 정의 -->
- 각 멤버가 특정 사진을 선택하는 기능 구현 예정
- 각 멤버 정보 요청/응답에서 멤버의 이미지 URL을 추가하여야 함

## To-Be
<!-- 변경 사항 -->
- Facade - Service 로직 개선
  - 기존에는 멤버 생성시 서비스에서 nickname 만 받았으나, 이제는 Member 도메인 객체를 받도록 함
- Facade, Service 메서드 시그니처 변경으로 인한 테스트 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1213" height="604" alt="image" src="https://github.com/user-attachments/assets/43937611-2218-442c-9d5d-535892bec0b8" />

## (Optional) Additional Description
- 머지는 포메 작업 끝나면, 같이 진행할 예정