### PR TITLE
[FIX] 7차 스프린트 QA 반영 (안내 모달 추가, 방장만 게임중단 버튼 렌더링)

### DIFF
--- a/frontend/src/components/layout/Header/RoundResultHeader/RoundResultHeader.tsx
+++ b/frontend/src/components/layout/Header/RoundResultHeader/RoundResultHeader.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+import { useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { gameTitle, headerLayout, roundText, stopButton } from '../Header.styled';
@@ -6,15 +7,27 @@ import { useStopGameMutation } from '../hooks';
 
 import A11yOnly from '@/components/common/A11yOnly/A11yOnly';
 
-import { useBalanceContentQuery, useFocus } from '@/hooks';
+import { AlertModal } from '@/components';
+import { useBalanceContentQuery, useFocus, useModal } from '@/hooks';
 
 // 좌측 상단 라운드, 가운데 제목 차지하는 헤더 (API 호출 O) : 라운드 통계 화면
 const RoundResultHeader = () => {
   const { roomId } = useParams();
   const { mutate: stopGame } = useStopGameMutation(Number(roomId));
   const { balanceContent } = useBalanceContentQuery(Number(roomId));
+  const { showModal } = useModal();
+  const returnFocusRef = useRef<HTMLButtonElement>(null);
   const screenReaderRoundResult = `${balanceContent.totalRound}라운드 중. ${balanceContent.currentRound}라운드. 투표 결과 페이지`;
   const focusRef = useFocus<HTMLElement>();
+
+  const handleStopGame = () => {
+    showModal(AlertModal, {
+      title: '게임 중단',
+      message: '게임을 중단하고 결과 화면으로 이동하시겠습니까?',
+      onConfirm: stopGame,
+      returnFocusRef,
+    });
+  };
 
   return (
     <header css={headerLayout()} tabIndex={0} ref={focusRef}>
@@ -26,7 +39,7 @@ const RoundResultHeader = () => {
         투표 결과
       </h1>
       <div>
-        <button css={stopButton} onClick={() => stopGame()}>
+        <button ref={returnFocusRef} css={stopButton} onClick={handleStopGame}>
           게임중단
         </button>
       </div>

--- a/frontend/src/components/layout/Header/RoundResultHeader/RoundResultHeader.tsx
+++ b/frontend/src/components/layout/Header/RoundResultHeader/RoundResultHeader.tsx
@@ -8,7 +8,7 @@ import { useStopGameMutation } from '../hooks';
 import A11yOnly from '@/components/common/A11yOnly/A11yOnly';
 
 import { AlertModal } from '@/components';
-import { useBalanceContentQuery, useFocus, useModal } from '@/hooks';
+import { useBalanceContentQuery, useFocus, useIsMaster, useModal } from '@/hooks';
 
 // 좌측 상단 라운드, 가운데 제목 차지하는 헤더 (API 호출 O) : 라운드 통계 화면
 const RoundResultHeader = () => {
@@ -19,6 +19,7 @@ const RoundResultHeader = () => {
   const returnFocusRef = useRef<HTMLButtonElement>(null);
   const screenReaderRoundResult = `${balanceContent.totalRound}라운드 중. ${balanceContent.currentRound}라운드. 투표 결과 페이지`;
   const focusRef = useFocus<HTMLElement>();
+  const isMaster = useIsMaster();
 
   const handleStopGame = () => {
     showModal(AlertModal, {
@@ -39,9 +40,11 @@ const RoundResultHeader = () => {
         투표 결과
       </h1>
       <div>
-        <button ref={returnFocusRef} css={stopButton} onClick={handleStopGame}>
-          게임중단
-        </button>
+        {isMaster && (
+          <button ref={returnFocusRef} css={stopButton} onClick={handleStopGame}>
+            게임중단
+          </button>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Issue Number
#490 

## As-Is
<!-- 문제 상황 정의 -->
1. 게임 중단 버튼을 누르면 안내 모달 뜨는 기능이 누락되어 바로 게임 중단이 되는 문제
2. 모두에게 게임 중단 버튼이 렌더링 되는 문제

## To-Be
<!-- 변경 사항 -->
- [x] 게임 중단 버튼 누르면 안내 모달 구현
- [x] 게임 중단 버튼 조건부 렌더링 (방장만)
- [x] 게임 중단 버튼이 있거나 없거나 헤더 타이틀의 위치가 정중앙이 되도록 스타일 수정


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
- 방장인 경우
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/bdf97b5a-8b5f-4fdc-8e39-fc1b976286ca" />
- 방장이 아닌 경우
<img width="754" height="1340" alt="image" src="https://github.com/user-attachments/assets/8c7d2218-4dc3-4018-9c24-7f0f77dfc132" />


## (Optional) Additional Description
