### PR TITLE
[REFACTOR] 이미지 URL 기본 값 제거

### DIFF
--- a/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
+++ b/backend/src/main/java/ddangkong/facade/room/dto/RoomJoinRequest.java
@@ -6,14 +6,7 @@ public record RoomJoinRequest(
         @NotBlank
         String nickname,
 
+        @NotBlank
         String imageUrl
 ) {
-
-    @Override
-    public String imageUrl() { // TODO : FE 작업 끝난 후 삭제 예정
-        if (imageUrl == null || imageUrl.isBlank()) {
-            return "https://velog.velcdn.com/images/gwichanlee/post/dfdaead8-d98a-4d42-a975-2fb3edd7dde6/image.png";
-        }
-        return imageUrl;
-    }
 }


### PR DESCRIPTION
## Issue Number
#492 

## As-Is
<!-- 문제 상황 정의 -->
- FE 유저 별 이미지 설정 기능이 완성됨에 따라 `imageUrl` 기본값 제거 필요

## To-Be
<!-- 변경 사항 -->
- `RoomJoinRequest`에 있는 `imageUrl`의 기본값 제거

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1188" height="371" alt="image" src="https://github.com/user-attachments/assets/7a23e810-8aa8-47de-9883-af1d0fc86485" />

## (Optional) Additional Description
